### PR TITLE
TOLK-191 UU

### DIFF
--- a/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.css
+++ b/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.css
@@ -246,41 +246,19 @@ section.sub-form:last-child {
     height: fit-content;
 }
 
-.navds-modal__button--shake {
-    transform: rotate(0deg);
-    transition: transform 100ms cubic-bezier(0.82, 2, 1, 0.3);
-}
-
-.navds-button--secondary {
-    border-color: transparent;
-    background-color: transparent;
-}
-
-.navds-modal__button svg {
-    height: 1.5rem;
-    width: 1.5rem;
-}
-
-.navds-button--s > svg {
-    font-size: 1.25rem;
-    width: 1.25rem;
-    height: 1.25rem;
-}
-
 .navds-button {
     cursor: pointer;
     background-color: #ffffff;
-    color: #a32a17;
+    color: #ba3a26;
     text-align: center;
     text-decoration: none;
     align-items: center;
     padding: 0;
-}
-
-.navds-button--secondary:active {
-    color: #ffffff;
+    font-weight: bold;
+    border-color: transparent;
+    background-color: transparent;
 }
 
 .navds-button--secondary:hover {
-    opacity: 0.8;
+    opacity: 0.7;
 }

--- a/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.css
+++ b/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.css
@@ -248,7 +248,6 @@ section.sub-form:last-child {
 
 .navds-button {
     cursor: pointer;
-    background-color: #ffffff;
     color: #ba3a26;
     text-align: center;
     text-decoration: none;

--- a/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.html
+++ b/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.html
@@ -399,43 +399,31 @@
                                 ></c-checkbox>
                             </div>
                             <div if:true={filesChanged} class="filesClass">
-                                <template for:each={fileData} for:item="file" for:index="index">
-                                    <div key={file.filename} class="fileAndButton">
-                                        <span key={file.filename} class="fileNameClass">{file.filename}</span>
-                                        <button
-                                            onfocus={onFileFocus}
-                                            aria-label={fileButtonLabel}
-                                            data-index={index}
-                                            key={file.filename}
-                                            type="button"
-                                            value={file.filename}
-                                            class="
-                                                navds-modal__button navds-modal__button--shake
-                                                navds-button navds-button--secondary navds-button--s
-                                                navds-body-short
-                                                navds-body--s
-                                            "
-                                            onclick={onFileButtonClick}
-                                        >
-                                            <svg
-                                                width="1em"
-                                                height="1em"
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                focusable="false"
-                                                role="img"
-                                            >
-                                                <path
-                                                    fill-rule="evenodd"
-                                                    clip-rule="evenodd"
-                                                    d="M21 4.385L13.385 12 21 19.615 19.615 21 12 13.385 4.385 21 3 19.615 10.615 12 3 4.385 4.385 3 12 10.615 19.615 3 21 4.385z"
-                                                    fill="currentColor"
-                                                ></path>
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </template>
+                                <ul aria-label="Liste over filer">
+                                    <template for:each={fileData} for:item="file" for:index="index">
+                                        <div key={file.filename} class="fileAndButton">
+                                            <li>
+                                                <span key={file.filename} class="fileNameClass">{file.filename}</span>
+                                                <button
+                                                    onfocus={onFileFocus}
+                                                    aria-label={fileButtonLabel}
+                                                    data-index={index}
+                                                    key={file.filename}
+                                                    type="button"
+                                                    value={file.filename}
+                                                    class="
+                                                        navds-button navds-button--secondary navds-button--s
+                                                        navds-body-short
+                                                        navds-body--s
+                                                    "
+                                                    onclick={onFileButtonClick}
+                                                >
+                                                    Slett
+                                                </button>
+                                            </li>
+                                        </div>
+                                    </template>
+                                </ul>
                             </div>
                         </div>
 

--- a/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.html
+++ b/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.html
@@ -401,27 +401,25 @@
                             <div if:true={filesChanged} class="filesClass">
                                 <ul aria-label="Liste over filer">
                                     <template for:each={fileData} for:item="file" for:index="index">
-                                        <div key={file.filename} class="fileAndButton">
-                                            <li>
-                                                <span key={file.filename} class="fileNameClass">{file.filename}</span>
-                                                <button
-                                                    onfocus={onFileFocus}
-                                                    aria-label={fileButtonLabel}
-                                                    data-index={index}
-                                                    key={file.filename}
-                                                    type="button"
-                                                    value={file.filename}
-                                                    class="
-                                                        navds-button navds-button--secondary navds-button--s
-                                                        navds-body-short
-                                                        navds-body--s
-                                                    "
-                                                    onclick={onFileButtonClick}
-                                                >
-                                                    Slett
-                                                </button>
-                                            </li>
-                                        </div>
+                                        <li key={file.filename} class="fileAndButton">
+                                            <span key={file.filename} class="fileNameClass">{file.filename}</span>
+                                            <button
+                                                onfocus={onFileFocus}
+                                                aria-label={fileButtonLabel}
+                                                data-index={index}
+                                                key={file.filename}
+                                                type="button"
+                                                value={file.filename}
+                                                class="
+                                                    navds-button navds-button--secondary navds-button--s
+                                                    navds-body-short
+                                                    navds-body--s
+                                                "
+                                                onclick={onFileButtonClick}
+                                            >
+                                                Slett
+                                            </button>
+                                        </li>
                                     </template>
                                 </ul>
                             </div>

--- a/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.js
+++ b/force-app/main/userCommunity/lwc/hot_createRequestForm/hot_createRequestForm.js
@@ -712,7 +712,6 @@ export default class RecordFormCreateExample extends NavigationMixin(LightningEl
         this.boolSwitch();
         this.showOrHideCheckbox();
         this.setCheckboxContent();
-        this.resetFileValue();
     }
 
     checkboxContent;
@@ -758,6 +757,7 @@ export default class RecordFormCreateExample extends NavigationMixin(LightningEl
                     this.boolSwitch();
                 }
             });
+            this.resetFileValue();
             this.setCheckboxContent();
             this.showOrHideCheckbox();
         } catch (err) {


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-191

Fjernet rødt kryss med "Slett"-tekst. Lagt filer som blir lastet opp i en ul-tag, som leser "Liste over filer", før den navngir alle filer og slett-knappen.

Merk: Når bruker laster opp fil og blir automatisk navigert tilbake til nettleser fra filutforsker vil skjermleser lese opp informasjon fra Google Chrome nivå, og ikke kun den fokuserte checkboxen.