### PR TITLE
Frilans bugs

### DIFF
--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
@@ -12,8 +12,12 @@
                 <p>Frist dato: <span>{interestedResource.AppointmentDeadlineDate__c}</span></p>
                 <p>Region: <span>{interestedResource.AppointmentServiceTerritory__c}</span></p>
                 <p>Tema: <span>{interestedResource.ServiceAppointmentFreelanceSubject__c}</span></p>
-                <p>Avlyst dato: <span>{interestedResource.WorkOrderCanceledDate__c}</span></p>
-                <p>Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span></p>
+                <p if:true={interestedResource.WorkOrderCanceledDate__c}>
+                    Avlyst dato: <span>{interestedResource.WorkOrderCanceledDate__c}</span>
+                </p>
+                <p if:true={interestedResource.HOT_TermsOfAgreement__c}>
+                    Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>
+                </p>
             </div>
             <c-button
                 disabled={isNotRetractable}

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -33,6 +33,24 @@ export default class Hot_interestedResourcesList extends LightningElement {
         this.dispatchEvent(eventToSend);
     }
 
+    setPreviousFiltersOnRefresh() {
+        if (sessionStorage.getItem('interestedfilters')) {
+            this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('interestedfilters')), setRecords: true }});
+            sessionStorage.clear();
+        }
+        this.sendFilters();
+    }
+
+    disconnectedCallback() {
+        // Going back with browser back or back button on mouse forces page refresh and a disconnect
+        // Save filters on disconnect to exist only within the current browser tab
+        sessionStorage.setItem('interestedfilters', JSON.stringify(this.filters))
+    }
+
+    renderedCallback() {
+        this.setPreviousFiltersOnRefresh();
+    }
+
     connectedCallback() {
         this.setColumns();
         refreshApex(this.wiredInterestedResourcesResult);

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -44,7 +44,7 @@ export default class Hot_interestedResourcesList extends LightningElement {
     disconnectedCallback() {
         // Going back with browser back or back button on mouse forces page refresh and a disconnect
         // Save filters on disconnect to exist only within the current browser tab
-        sessionStorage.setItem('interestedfilters', JSON.stringify(this.filters))
+        sessionStorage.setItem('interestedfilters', JSON.stringify(this.filters));
     }
 
     renderedCallback() {

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
@@ -6,7 +6,7 @@
                 <p>Tema: <span>{serviceAppointment.Subject}</span></p>
                 <p>Tid: <span>{serviceAppointment.StartAndEndDate}</span></p>
                 <p>Faktisk start: <span>{serviceAppointment.ActualStartTime}</span></p>
-                <p>faktisk slutt: <span>{serviceAppointment.ActualEndTime}</span></p>
+                <p>Faktisk slutt: <span>{serviceAppointment.ActualEndTime}</span></p>
                 <p>Adresse: <span>{serviceAppointment.HOT_AddressFormated__c}</span></p>
                 <p>Region: <span>{serviceAppointment.HOT_ServiceTerritoryName__c}</span></p>
                 <p>Status: <span>{serviceAppointment.Status}</span></p>
@@ -14,7 +14,9 @@
                 <p if:true={serviceAppointment.HOT_Escort__c}>
                     Ledsaging: <span>{serviceAppointment.HOT_Escort__c}</span>
                 </p>
-                <p>Vedtak: <span>{serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}</span></p>
+                <p if:true={serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}>
+                    Vedtak: <span>{serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}</span>
+                </p>
                 <p>Tolkemetode: <span>{serviceAppointment.HOT_WorkTypeName__c}</span></p>
                 <p if:true={interestedResource}>
                     Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -27,6 +27,24 @@ export default class Hot_myServiceAppointments extends LightningElement {
         const eventToSend = new CustomEvent('senddetail', { detail: this.isDetails });
         this.dispatchEvent(eventToSend);
     }
+    
+    setPreviousFiltersOnRefresh() {
+        if (sessionStorage.getItem('myfilters')) {
+            this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('myfilters')), setRecords: true }});
+            sessionStorage.clear();
+        }
+        this.sendFilters();
+    }
+
+    disconnectedCallback() {
+        // Going back with browser back or back button on mouse forces page refresh and a disconnect
+        // Save filters on disconnect to exist only within the current browser tab
+        sessionStorage.setItem('myfilters', JSON.stringify(this.filters))
+    }
+
+    renderedCallback() {
+        this.setPreviousFiltersOnRefresh();
+    }
 
     @track filters = [];
     connectedCallback() {

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -39,7 +39,7 @@ export default class Hot_myServiceAppointments extends LightningElement {
     disconnectedCallback() {
         // Going back with browser back or back button on mouse forces page refresh and a disconnect
         // Save filters on disconnect to exist only within the current browser tab
-        sessionStorage.setItem('myfilters', JSON.stringify(this.filters))
+        sessionStorage.setItem('myfilters', JSON.stringify(this.filters));
     }
 
     renderedCallback() {

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.css
@@ -8,6 +8,35 @@
     text-align: end;
 }
 
+.submit, .submitted-error, .submitted-loading, .submitted-true {
+    display: flex; 
+    align-items: center; 
+    justify-content: center; 
+    flex-direction: column;
+    text-align: center;
+}
+
+.loader {
+    border: 16px solid #f3f3f3;
+    /* Light grey */
+    border-top: 16px solid #3498db;
+    /* Blue */
+    border-radius: 50%;
+    width: 80px;
+    height: 80px;
+    animation: spin 1s linear infinite;
+    justify-content: center
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 .record-details-container {
     margin: 2rem 0;
     display: flex;

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
@@ -23,6 +23,8 @@
             onbuttonclick={sendInterest}
             desktop-style="width: 12rem; justify-content: center; margin-bottom: 1rem;"
             mobile-style="width: 12rem; justify-content: center; margin-bottom: 1rem;"
+            title="Huk av sjekkboks i listen over oppdrag for å melde interesse"
+            disabled={sendInterestedButtonDisabled}
         >
         </c-button>
         <div if:false={noServiceAppointments}>
@@ -33,6 +35,7 @@
                 onrowclick={goToRecordDetails}
                 checkbox="true"
                 checked-rows={checkedServiceAppointments}
+                onamountofcheckedrows={setSendInterestedButtonState}
             ></c-table>
         </div>
         <div if:true={noServiceAppointments} style="text-align: center">
@@ -53,7 +56,7 @@
             aria-labelledby="comment-header-id"
         >
             <section>
-                <div>
+                <div class="comment-details">
                     <h2 id="comment-header-id" class="typo-undertittel">Legg til kommentarer til oppdragene</h2>
 
                     <template iterator:it={serviceAppointmentCommentDetails}>
@@ -89,16 +92,56 @@
                             </lightning-input-field>
                         </lightning-record-edit-form>
                     </template>
-
-                    <lightning-button
-                        class="slds-m-left_x-small"
-                        variant="brand"
-                        type="submit"
-                        label="Send inn"
-                        onclick={registerInterest}
-                    >
-                    </lightning-button>
                 </div>
+                <div class="submit">
+                    <div class="submitted-true hidden">
+                        <lightning-icon
+                            icon-name="utility:success"
+                            alternative-text="Suksess"
+                            title="Suksess"
+                            variant="success"
+                            size="large"
+                        >
+                        </lightning-icon>
+                        <br />
+                        <h2 class="typo-undertittel h2-successMessage" id="successMessage" tabindex="-1" role="alert" aria-live="polite">
+                            Interesse er meldt.
+                        </h2>
+                        <br/>
+                        <c-button
+                            button-styling="primary"
+                            button-label="OK"
+                            onbuttonclick={closeModal}
+                            desktop-style="width: 8rem; justify-content: center"
+                            mobile-style="width: 8rem; justify-content: center"
+                        ></c-button>
+                    </div>
+                    <div class="submitted-loading hidden">
+                            <h2 class="typo-undertittel h2-loadingMessage" id="loadingMessage" tabindex="-1" role="alert" aria-live="polite">
+                                Melder interesse...
+                            </h2>
+                            <br/>
+                            <div if:true={spin} class="loader"></div>
+                            <br />
+                    </div>
+                    <div class="submitted-error hidden">
+                        <h2 class="typo-undertittel h2-loadingMessage" id="errorMessage" tabindex="-1" role="alert" aria-live="polite">
+                            Noe gikk galt under melding av interesse.
+                        </h2>
+                        <br/>
+                        <h3>Feilmelding: {errorMessage}</h3>
+                        <br />
+                    </div>
+                </div>
+                    <c-button
+                        class="send-inn-button"
+                        button-styling="primary"
+                        button-label="Send inn"
+                        type="submit"
+                        onbuttonclick={registerInterest}
+                        desktop-style="width: 8rem; justify-content: center"
+                        mobile-style="width: 8rem; justify-content: center"
+                    ></c-button>
             </section>
             <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
                 <span class="text-hide">Lukk</span>

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
@@ -70,15 +70,11 @@
                                 <p>Tid: <span>{it.value.StartAndEndDate}</span></p>
                                 <p>Tema: <span>{it.value.HOT_FreelanceSubject__c}</span></p>
                                 <p>Adresse: <span>{it.value.HOT_AddressFormated__c}</span></p>
-                                <p>
-                                    Antall påmeldte:
-                                    <span>{it.value.HOT_NumberOfInterestedResources__c}</span>
-                                </p>
                                 <p>Tolkemetode: <span>{it.value.HOT_WorkTypeName__c}</span></p>
                                 <p>Frigitt av: <span>{it.value.HOT_ReleasedBy__c}</span></p>
                                 <p>Frigitt dato: <span>{it.value.HOT_ReleaseDate__c}</span></p>
                                 <p>
-                                    Antall påmeldte:
+                                    Antall påmeldte: 
                                     <span>{it.value.HOT_NumberOfInterestedResources__c}</span>
                                 </p>
                                 <p>Region: <span>{it.value.HOT_ServiceTerritoryName__c}</span></p>

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -41,7 +41,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
     disconnectedCallback() {
         // Going back with browser back or back button on mouse forces page refresh and a disconnect
         // Save filters on disconnect to exist only within the current browser tab
-        sessionStorage.setItem('openfilters', JSON.stringify(this.filters))
+        sessionStorage.setItem('openfilters', JSON.stringify(this.filters));
     }
 
     renderedCallback() {

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -17,12 +17,6 @@ export default class Hot_openServiceAppointments extends LightningElement {
         }
     }
 
-    disconnectedCallback() {
-        // Going back with browser back or back button on mouse forces page refresh and a disconnect
-        // Save filters on disconnect to exist only within the current browser tab
-        sessionStorage.setItem('filters', JSON.stringify(this.filters))
-    }
-
     sendFilters() {
         const eventToSend = new CustomEvent('sendfilters', { detail: this.filters });
         this.dispatchEvent(eventToSend);
@@ -37,11 +31,17 @@ export default class Hot_openServiceAppointments extends LightningElement {
     }
 
     setPreviousFiltersOnRefresh() {
-        if (sessionStorage.getItem('filters')) {
-            this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('filters')), setRecords: true }});
+        if (sessionStorage.getItem('openfilters')) {
+            this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('openfilters')), setRecords: true }});
             sessionStorage.clear();
         }
         this.sendFilters();
+    }
+
+    disconnectedCallback() {
+        // Going back with browser back or back button on mouse forces page refresh and a disconnect
+        // Save filters on disconnect to exist only within the current browser tab
+        sessionStorage.setItem('openfilters', JSON.stringify(this.filters))
     }
 
     renderedCallback() {

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -18,6 +18,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
     }
 
     disconnectedCallback() {
+        // Going back with browser back or back button on mouse forces page refresh and a disconnect
         // Save filters on disconnect to exist only within the current browser tab
         sessionStorage.setItem('filters', JSON.stringify(this.filters))
     }
@@ -175,13 +176,16 @@ export default class Hot_openServiceAppointments extends LightningElement {
                 this.spin = false;
                 this.template.querySelector('.submitted-loading').classList.add('hidden');
                 this.template.querySelector('.submitted-true').classList.remove('hidden');
+                this.template.querySelector('c-table').unsetCheckboxes();
+                this.sendInterestedButtonDisabled = true; // Set button to disabled when interest is sent successfully
+                refreshApex(this.wiredAllServiceAppointmentsResult);
             }).catch((error) => {
                 this.spin = false;
+                this.sendInterestedButtonDisabled = false;
                 this.template.querySelector('.submitted-loading').classList.add('hidden');
                 this.template.querySelector('.submitted-error').classList.remove('hidden');
                 this.errorMessage = error;
             });
-            refreshApex(this.wiredAllServiceAppointmentsResult);
         }
     }
 
@@ -190,6 +194,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
         this.template.querySelector('.send-inn-button').classList.remove('hidden');
     }
 
+    // Set button state when checkbox clicked
     setSendInterestedButtonState(event) {
         this.sendInterestedButtonDisabled = event.detail > 0 ? false : true;
     }

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -178,7 +178,12 @@ export default class Hot_openServiceAppointments extends LightningElement {
                 this.template.querySelector('.submitted-true').classList.remove('hidden');
                 this.template.querySelector('c-table').unsetCheckboxes();
                 this.sendInterestedButtonDisabled = true; // Set button to disabled when interest is sent successfully
-                refreshApex(this.wiredAllServiceAppointmentsResult);
+                let currentFilters = this.filters;
+                refreshApex(this.wiredAllServiceAppointmentsResult).then(() => {
+                    // Since refreshApex causes the wired methods to run again, the default filters will override current filters.
+                    // Apply previous filter
+                    this.applyFilter({ detail: { filterArray: currentFilters, setRecords: true }});
+                });
             }).catch((error) => {
                 this.spin = false;
                 this.sendInterestedButtonDisabled = false;

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -59,7 +59,7 @@ export default class Hot_wageClaimList extends LightningElement {
     disconnectedCallback() {
         // Going back with browser back or back button on mouse forces page refresh and a disconnect
         // Save filters on disconnect to exist only within the current browser tab
-        sessionStorage.setItem('wageclaimfilters', JSON.stringify(this.filters))
+        sessionStorage.setItem('wageclaimfilters', JSON.stringify(this.filters));
     }
 
     renderedCallback() {

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -31,7 +31,6 @@ export default class Hot_wageClaimList extends LightningElement {
             let tempRecords = [];
             for (let record of result.data) {
                 tempRecords.push(formatRecord(Object.assign({}, record), this.datetimeFields));
-                console.log(tempRecords[tempRecords.length - 1].StartAndEndDate);
             }
             this.wageClaims = tempRecords;
             this.allWageClaimsWired = this.wageClaims;

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -48,6 +48,24 @@ export default class Hot_wageClaimList extends LightningElement {
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
     }
 
+    setPreviousFiltersOnRefresh() {
+        if (sessionStorage.getItem('wageclaimfilters')) {
+            this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('wageclaimfilters')), setRecords: true }});
+            sessionStorage.clear();
+        }
+        this.sendFilters();
+    }
+
+    disconnectedCallback() {
+        // Going back with browser back or back button on mouse forces page refresh and a disconnect
+        // Save filters on disconnect to exist only within the current browser tab
+        sessionStorage.setItem('wageclaimfilters', JSON.stringify(this.filters))
+    }
+
+    renderedCallback() {
+        this.setPreviousFiltersOnRefresh();
+    }
+
     datetimeFields = [{ name: 'StartAndEndDate', type: 'datetimeinterval', start: 'StartTime__c', end: 'EndTime__c' }];
     connectedCallback() {
         this.setColumns();


### PR DESCRIPTION
- Viser bekreftelse/error til bruker ved sending av interesse for å unngå forvirring om scriptet f.eks. skulle returnere error og stoppe.

- Meld interesse knapp er nå disabled inntil én eller flere sjekkbokser er valgt, slik at bruken av knappen ikke kan misforstås.

- Fikset problem ved at ingen detaljer eller kommentarfelt vises. Var pga. recordMap ikke var i sync med records og nettleser etter at man har filtrert/sendt inn interesse på et oppdrag som gjør at lista blir endret (prøvde å hente ID til en record som ikke var i lista).
- Filtrering for åpne oppdrag lagres nå i sesjonens tab, slik at den bevares ved refresh og ved bruk av tilbakeknapp på mus (som forårsaker refresh). 

**Note: Filter for forrige tab lagres ikke om man går inn i ny tab og endrer filter der uten å gå inn i en record, fordi da disconnectes man ikke. Får bli en QOL update senere å lagre filter når man trykker tilbake-knappen eller på en tab og.**