### PR TITLE
fix to filter storage and minor fixes

### DIFF
--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
@@ -22,7 +22,7 @@
             <c-button
                 disabled={isNotRetractable}
                 onbuttonclick={retractInterest}
-                button-styling="Secondary"
+                button-styling="Primary"
                 type="Submit"
                 button-label="Tilbaketrekk interesse"
             >

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -36,7 +36,7 @@ export default class Hot_interestedResourcesList extends LightningElement {
     setPreviousFiltersOnRefresh() {
         if (sessionStorage.getItem('interestedfilters')) {
             this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('interestedfilters')), setRecords: true }});
-            sessionStorage.clear();
+            sessionStorage.removeItem('interestedfilters');
         }
         this.sendFilters();
     }

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -31,7 +31,7 @@ export default class Hot_myServiceAppointments extends LightningElement {
     setPreviousFiltersOnRefresh() {
         if (sessionStorage.getItem('myfilters')) {
             this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('myfilters')), setRecords: true }});
-            sessionStorage.clear();
+            sessionStorage.removeItem('myfilters');
         }
         this.sendFilters();
     }

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
@@ -23,7 +23,7 @@
             onbuttonclick={sendInterest}
             desktop-style="width: 12rem; justify-content: center; margin-bottom: 1rem;"
             mobile-style="width: 12rem; justify-content: center; margin-bottom: 1rem;"
-            title="Huk av sjekkboks i listen over oppdrag for å melde interesse"
+            title="Merk sjekkboks i listen for å melde interesse"
             disabled={sendInterestedButtonDisabled}
         >
         </c-button>

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -33,7 +33,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
     setPreviousFiltersOnRefresh() {
         if (sessionStorage.getItem('openfilters')) {
             this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('openfilters')), setRecords: true }});
-            sessionStorage.clear();
+            sessionStorage.removeItem('openfilters');
         }
         this.sendFilters();
     }
@@ -115,7 +115,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
     datetimeFields = [
         { name: 'StartAndEndDate', type: 'datetimeinterval', start: 'EarliestStartTime', end: 'DueDate' },
         { name: 'HOT_DeadlineDate__c', type: 'date' },
-        { name: 'HOT_ReleaseDate__c', type: 'date', newName: 'ReleaseDate' }
+        { name: 'HOT_ReleaseDate__c', type: 'date' }
     ];
 
     @track serviceAppointment;

--- a/force-app/main/userCommunity/lwc/hot_home/hot_home.js
+++ b/force-app/main/userCommunity/lwc/hot_home/hot_home.js
@@ -28,6 +28,7 @@ export default class Hot_home extends NavigationMixin(LightningElement) {
 
     @track pageLinks = {};
     connectedCallback() {
+        sessionStorage.clear(); // Clear session storage when on home
         window.scrollTo(0, 0);
         let baseURLArray = window.location.pathname.split('/');
         baseURLArray.pop();

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.html
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.html
@@ -6,7 +6,7 @@
             </div>
             <div if:true={noWageClaims} style="text-align: center">
                 <br />
-                Du har ingen ledig med lønn oppdrag.
+                Du har ingen ledig på lønn oppdrag.
             </div>
         </div>
         <div if:true={isWageClaimDetails}>

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -51,7 +51,7 @@ export default class Hot_wageClaimList extends LightningElement {
     setPreviousFiltersOnRefresh() {
         if (sessionStorage.getItem('wageclaimfilters')) {
             this.applyFilter({ detail: { filterArray: JSON.parse(sessionStorage.getItem('wageclaimfilters')), setRecords: true }});
-            sessionStorage.clear();
+            sessionStorage.removeItem('wageclaimfilters');
         }
         this.sendFilters();
     }


### PR DESCRIPTION
- Filters blir nå lagra når man navigerer rundt på tabs. Eneste gangen filter blir resatt på andre tabs er når man melder interesse på et oppdrag i Ledige Oppdrag tabben. Det virker som at det som blir lagret i sesjonen blir nullet ut når man submitter. Prøvd med localStorage og det fungerer heller ikke, så usikker på nøyaktig hva som skjer.