### PR TITLE
Tolk 2022 - sentrere brødsmulesti og legge til tilbakeknapp min side

### DIFF
--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
@@ -14,7 +14,6 @@
     flex-grow: 0;
     overflow-x: auto;
     margin-bottom: 1rem;
-    margin-top: 1rem;
     max-width: 800px;
     width: 100%;
 }
@@ -31,4 +30,17 @@
 .sub-form > form > slot > lightning-output-field > .slds-form-element__label {
     background-color: red;
     display: none !important;
+}
+.back-link {
+    display: flex;
+    align-items: left;
+    text-decoration: none;
+    max-width: fit-content;
+}
+.back-link-div {
+    left: 0;
+    margin-top: 0;
+    padding: 0;
+    max-width: 800px;
+    width: 100%;
 }

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
@@ -39,9 +39,7 @@
 }
 .back-link-div {
     display: flex;
-
     max-width: 800px;
-
     width: 100%;
 }
 .back-link:hover {

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.css
@@ -8,7 +8,7 @@
 .user-info-tile {
     background-color: #fff;
     display: block;
-    padding: 4rem 2rem;
+    padding: 3rem 2rem;
     border-radius: 4px;
     position: relative;
     flex-grow: 0;
@@ -38,9 +38,12 @@
     max-width: fit-content;
 }
 .back-link-div {
-    left: 0;
-    margin-top: 0;
-    padding: 0;
+    display: flex;
+
     max-width: 800px;
+
     width: 100%;
+}
+.back-link:hover {
+    text-decoration: underline;
 }

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.html
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.html
@@ -1,6 +1,12 @@
 <template>
     <div class="user-info-wrapper center-content">
         <div class="user-info-tile center-content">
+            <div class="back-link-div">
+                <a class="back-link" onclick={goBack}>
+                    <c-icon icon="Back"></c-icon>
+                    <p style="margin-left: 0.25rem">Tilbake</p>
+                </a>
+            </div>
             <section>
                 <lightning-record-view-form object-api-name="Person__c" record-id={recordId}>
                     <section class="bruker-info-skjema sub-form">

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
@@ -11,4 +11,14 @@ export default class hot_userContactInformation extends LightningElement {
             this.recordId = this.person.Id;
         }
     }
+
+    goBack() {
+        this[NavigationMixin.Navigate]({
+            type: 'comm__namedPage',
+            attributes: {
+                pageName: 'home'
+            }
+        });
+        alert('knapp fungerer');
+    }
 }

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
@@ -3,7 +3,6 @@ import { NavigationMixin } from 'lightning/navigation';
 import getPersonPhoneEmailAndStatus from '@salesforce/apex/HOT_UserInformationController.getPersonPhoneEmailAndStatus';
 import updateKrrStatus from '@salesforce/apex/HOT_UserInformationController.updateKrrStatus';
 
-
 export default class hot_userContactInformation extends NavigationMixin(LightningElement) {
     @track person;
     @track recordId;
@@ -22,7 +21,7 @@ export default class hot_userContactInformation extends NavigationMixin(Lightnin
                 pageName: 'home'
             }
         });
-
+    }
     setKrrIntegrationStatusToQueued() {
         var personCloned = JSON.parse(JSON.stringify(this.person));
         try {

--- a/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
+++ b/force-app/main/userCommunity/lwc/hot_userContactInformation/hot_userContactInformation.js
@@ -1,7 +1,8 @@
 import { LightningElement, wire, track } from 'lwc';
 import getPersonPhoneEmail from '@salesforce/apex/HOT_UserInformationController.getPersonPhoneEmail';
+import { NavigationMixin } from 'lightning/navigation';
 
-export default class hot_userContactInformation extends LightningElement {
+export default class hot_userContactInformation extends NavigationMixin(LightningElement) {
     @track person;
     @track recordId;
     @wire(getPersonPhoneEmail)
@@ -19,6 +20,5 @@ export default class hot_userContactInformation extends LightningElement {
                 pageName: 'home'
             }
         });
-        alert('knapp fungerer');
     }
 }

--- a/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.css
+++ b/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.css
@@ -1,5 +1,4 @@
 .liste-max-width {
     max-width: 800px;
     width: 100%;
-    padding: 0 3.25rem;
 }

--- a/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.css
+++ b/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.css
@@ -1,5 +1,5 @@
 .liste-max-width {
-    max-width: 1480px;
+    max-width: 800px;
     width: 100%;
     padding: 0 3.25rem;
 }

--- a/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.html
+++ b/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.html
@@ -1,9 +1,6 @@
 <template>
     <div class="brodsmulesti">
-        <lightning-breadcrumbs class="liste-max-width">
-            <lightning-breadcrumb label="Tolketjenesten" href="/s/"> </lightning-breadcrumb>
-            <lightning-breadcrumb label="Min side"></lightning-breadcrumb>
-        </lightning-breadcrumbs>
+        <c-breadcrumbs url-list={breadcrumbs} class="liste-max-width"></c-breadcrumbs>
     </div>
 
     <c-hot_user-contact-information item-name="contactInformation"> </c-hot_user-contact-information>

--- a/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.html
+++ b/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.html
@@ -2,7 +2,7 @@
     <div class="brodsmulesti">
         <lightning-breadcrumbs class="liste-max-width">
             <lightning-breadcrumb label="Tolketjenesten" href="/s/"> </lightning-breadcrumb>
-            <lightning-breadcrumb label="Min side" href="/s/min-side"> </lightning-breadcrumb>
+            <lightning-breadcrumb label="Min side"></lightning-breadcrumb>
         </lightning-breadcrumbs>
     </div>
 

--- a/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.js
+++ b/force-app/main/userCommunity/lwc/hot_userInformation/hot_userInformation.js
@@ -1,4 +1,18 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, track, api } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 
-export default class hot_userInformation extends NavigationMixin(LightningElement) {}
+export default class hot_userInformation extends NavigationMixin(LightningElement) {
+    @track breadcrumbs = [];
+    connectedCallback() {
+        this.breadcrumbs = [
+            {
+                label: 'Tolketjenesten',
+                href: ''
+            },
+            {
+                label: 'Min side',
+                href: 'mine-side'
+            }
+        ];
+    }
+}


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2022
**Hva er gjort:**
Brødsmulestien som var langt uti huttiheita til venstre er nå sentrert sammen med de andre boksene på midten slik at alle sidene ser like ut. Måten brødsmulestien er laget på er også byttet ut.

Det er også lagt tilbakeknapp slik at bruker kan trykke seg tilbake til forsiden. 

**Testing:**

- Lag community + tolkbruker.
- Gå inn på Min side. 
- Sjekk at brødsmulestien ser lik ut på de andre sidene og sjekk at du kommer deg til forsiden ved å trykke "Tolketjenesten". 
- Gå inn på Min side igjen og sjekk at tilbakeknappen ligger fint og at du kommer deg til forsiden når du trykker på Tilbake. 
- Sjekk at alt ser bra ut på mobil. 
