### PR TITLE
Tolk 2185 - ikke kunne avlyse oppdrag fra fortiden serie

### DIFF
--- a/force-app/main/userCommunity/classes/HOT_RequestListController.cls
+++ b/force-app/main/userCommunity/classes/HOT_RequestListController.cls
@@ -205,21 +205,21 @@ public without sharing class HOT_RequestListController {
         return times;
     }
     @AuraEnabled
-    public static void updateRelatedWorkOrders(String requestId){
-          List<WorkOrder> workOrders = [
+    public static void updateRelatedWorkOrders(String requestId) {
+        List<WorkOrder> workOrders = [
             SELECT Id, Status, StartDate, EndDate
             FROM WorkOrder
             WHERE HOT_Request__r.Id = :requestId
         ];
         for (WorkOrder workOrder : workOrders) {
-            if(workOrder.StartDate > Datetime.now()){
+            if (workOrder.StartDate > Datetime.now()) {
                 workOrder.Status = 'Canceled';
             }
         }
         update workOrders;
-        HOT_Request__c request=[Select IsNotifyDispatcher__c, Status__c FROM HOT_Request__c WHERE Id=:requestId];
-       // request.Status__c='Avlyst';
-        request.IsNotifyDispatcher__c=true;
+
+        HOT_Request__c request = [SELECT IsNotifyDispatcher__c, Status__c FROM HOT_Request__c WHERE Id = :requestId];
+        request.IsNotifyDispatcher__c = true;
         update request;
     }
 }

--- a/force-app/main/userCommunity/classes/HOT_RequestListController.cls
+++ b/force-app/main/userCommunity/classes/HOT_RequestListController.cls
@@ -204,4 +204,22 @@ public without sharing class HOT_RequestListController {
         }
         return times;
     }
+    @AuraEnabled
+    public static void updateRelatedWorkOrders(String requestId){
+          List<WorkOrder> workOrders = [
+            SELECT Id, Status, StartDate, EndDate
+            FROM WorkOrder
+            WHERE HOT_Request__r.Id = :requestId
+        ];
+        for (WorkOrder workOrder : workOrders) {
+            if(workOrder.StartDate > Datetime.now()){
+                workOrder.Status = 'Canceled';
+            }
+        }
+        update workOrders;
+        HOT_Request__c request=[Select IsNotifyDispatcher__c, Status__c FROM HOT_Request__c WHERE Id=:requestId];
+       // request.Status__c='Avlyst';
+        request.IsNotifyDispatcher__c=true;
+        update request;
+    }
 }

--- a/force-app/main/userCommunity/classes/HOT_RequestListControllerTest.cls
+++ b/force-app/main/userCommunity/classes/HOT_RequestListControllerTest.cls
@@ -107,7 +107,7 @@ private class HOT_RequestListControllerTest {
         Boolean hasFile = file.size() > 0;
         System.assertEquals(true, hasFile, 'File was not uploaded');
     }
-     @isTest
+    @isTest
     private static void updateRelatedWorkOrdersCancel() {
         WorkType workType = HOT_TestDataFactory.createWorkType();
         insert workType;
@@ -136,16 +136,13 @@ private class HOT_RequestListControllerTest {
         workOrder3.EndDate = workOrder3.EndDate.addDays(3);
         workOrders.add(workOrder3);
 
-        Test.startTest();
         insert workOrders;
-    
+
+        Test.startTest();
         HOT_RequestListController.updateRelatedWorkOrders(request.Id);
-
-        List<WorkOrder> workOrdersCancelled=[Select Id, Status FROM WorkOrder WHERE Status='Canceled'];
-        
-        DateTime now=DateTime.now().addHours(3);
-        System.assertEquals(workOrdersCancelled.size(), 3, 'Ikke riktig avlyst');
-
+        List<WorkOrder> workOrdersCancelled = [SELECT Id, Status FROM WorkOrder WHERE Status = 'Canceled'];
         Test.stopTest();
+
+        System.assertEquals(workOrdersCancelled.size(), 3, 'Ikke riktig avlyst');
     }
 }

--- a/force-app/main/userCommunity/classes/HOT_RequestListControllerTest.cls
+++ b/force-app/main/userCommunity/classes/HOT_RequestListControllerTest.cls
@@ -107,4 +107,45 @@ private class HOT_RequestListControllerTest {
         Boolean hasFile = file.size() > 0;
         System.assertEquals(true, hasFile, 'File was not uploaded');
     }
+     @isTest
+    private static void updateRelatedWorkOrdersCancel() {
+        WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        insert request;
+
+        List<WorkOrder> workOrders = new List<WorkOrder>();
+
+        WorkOrder workOrder = HOT_TestDataFactory.createWorkOrder(request, workType);
+        workOrder.StartDate = workOrder.StartDate.addDays(-10);
+        workOrder.EndDate = workOrder.EndDate.addDays(-10);
+        workOrders.add(workOrder);
+
+        WorkOrder workOrder1 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        workOrder1.StartDate = workOrder1.StartDate.addDays(1);
+        workOrder1.EndDate = workOrder1.EndDate.addDays(1);
+        workOrders.add(workOrder1);
+
+        WorkOrder workOrder2 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        workOrder2.StartDate = workOrder2.StartDate.addDays(2);
+        workOrder2.EndDate = workOrder2.EndDate.addDays(2);
+        workOrders.add(workOrder2);
+
+        WorkOrder workOrder3 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        workOrder3.StartDate = workOrder3.StartDate.addDays(3);
+        workOrder3.EndDate = workOrder3.EndDate.addDays(3);
+        workOrders.add(workOrder3);
+
+        Test.startTest();
+        insert workOrders;
+    
+        HOT_RequestListController.updateRelatedWorkOrders(request.Id);
+
+        List<WorkOrder> workOrdersCancelled=[Select Id, Status FROM WorkOrder WHERE Status='Canceled'];
+        
+        DateTime now=DateTime.now().addHours(3);
+        System.assertEquals(workOrdersCancelled.size(), 3, 'Ikke riktig avlyst');
+
+        Test.stopTest();
+    }
 }

--- a/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
+++ b/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
@@ -1,5 +1,6 @@
 import { LightningElement, track, wire, api } from 'lwc';
 import getMyWorkOrdersAndRelatedRequest from '@salesforce/apex/HOT_WorkOrderListController.getMyWorkOrdersAndRelatedRequest';
+import updateRelatedWorkOrders from '@salesforce/apex/HOT_RequestListController.updateRelatedWorkOrders';
 import createThread from '@salesforce/apex/HOT_MessageHelper.createThread';
 import { CurrentPageReference, NavigationMixin } from 'lightning/navigation';
 import { columns, mobileColumns, workOrderColumns, workOrderMobileColumns, iconByValue } from './columns';
@@ -418,31 +419,44 @@ export default class MineBestillingerWrapper extends NavigationMixin(LightningEl
         this.template.querySelector('.loader').classList.remove('hidden');
         const fields = {};
         if (this.urlStateParameters.level === 'R') {
-            fields[REQUEST_ID.fieldApiName] = this.request.Id;
-            fields[STATUS.fieldApiName] = 'Avlyst';
-            fields[NOTIFY_DISPATCHER.fieldApiName] = true;
+            updateRelatedWorkOrders({ requestId: this.request.Id })
+                .then((result) => {
+                    refreshApex(this.wiredgetWorkOrdersResult);
+                    this.noCancelButton = true;
+                    this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
+                    this.template.querySelector('.loader').classList.add('hidden');
+                    this.modalContent = 'Bestillingen er avlyst.';
+                    this.showModal();
+                })
+                .catch((error) => {
+                    this.noCancelButton = true;
+                    this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
+                    this.template.querySelector('.loader').classList.add('hidden');
+                    this.modalContent = 'Kunne ikke avlyse denne bestillingen.';
+                    this.showModal();
+                });
         } else {
             fields[WORKORDER_ID.fieldApiName] = this.workOrder.Id;
             fields[WORKORDER_STATUS.fieldApiName] = 'Canceled';
             fields[WORKORDER_NOTIFY_DISPATCHER.fieldApiName] = true;
+            const recordInput = { fields };
+            updateRecord(recordInput)
+                .then(() => {
+                    refreshApex(this.wiredgetWorkOrdersResult);
+                    this.noCancelButton = true;
+                    this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
+                    this.template.querySelector('.loader').classList.add('hidden');
+                    this.modalContent = 'Bestillingen er avlyst.';
+                    this.showModal();
+                })
+                .catch(() => {
+                    this.noCancelButton = true;
+                    this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
+                    this.template.querySelector('.loader').classList.add('hidden');
+                    this.modalContent = 'Kunne ikke avlyse denne bestillingen.';
+                    this.showModal();
+                });
         }
-        const recordInput = { fields };
-        updateRecord(recordInput)
-            .then(() => {
-                refreshApex(this.wiredgetWorkOrdersResult);
-                this.noCancelButton = true;
-                this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
-                this.template.querySelector('.loader').classList.add('hidden');
-                this.modalContent = 'Bestillingen er avlyst.';
-                this.showModal();
-            })
-            .catch(() => {
-                this.noCancelButton = true;
-                this.template.querySelector('.ReactModal__Overlay').classList.add('hidden');
-                this.template.querySelector('.loader').classList.add('hidden');
-                this.modalContent = 'Kunne ikke avlyse denne bestillingen.';
-                this.showModal();
-            });
     }
 
     showUploadFilesComponent = false;


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2185

### **Hvorfor:** Om bruker avlyste seriebestilling ville alle oppdrag (også gjennomførte oppdrag fra fortiden) bli satt som avlyst og dette ville gå utover statistikken.
Nå vil ikke oppdrag som har en passert starttid bli satt som avlyst når man avlyser en seriebestilling.

### **Testing:**

- [ ] Lag serieoppdrag med start (bare om noen minutter til) og noen dager.
- [ ] Gå inn i salesforce og velg godkjent på forespørslen.
- [ ] Vent til klokkeslettet er passert
- [ ] Prøv å avlys en bestilling midt i. (altså bestilling/oppdrag i fremtiden). Det skal gå
- [ ] Prøv å avlys hele serien. Alle fremtidige bestillinger skal bli avlyst, men ikke den som har passert i starttid.
- [ ] Avlys serie knappen skal også være deaktivert.
- [ ] Gå inn i salesforce og sjekk at arbeidsordre og tilhørende oppdrag på forespørselen har fått status avlyst. Den arbeidsordre/oppdrag i fortiden skal ikke bli avlyst. 



- [ ] Lag en ny seriebestilling med alle oppdrag i fremtiden,
- [ ] Avlys hele serien. Hele serien skal da bli avlyst. 