### PR TITLE
Tolk 2158 - Feil i statusflyt ved ikke ledige tolker

### DIFF
--- a/force-app/main/fslStatusTransition/classes/HOT_WorkOrderLineItemStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_WorkOrderLineItemStatusHandler.cls
@@ -177,7 +177,7 @@ public without sharing class HOT_WorkOrderLineItemStatusHandler extends MyTrigge
                     workOrderLineItem.Status = 'Partially Complete';
                     continue;
                 }
-                if (numberOfServiceAppointments > 1 && numberOfCanceled >=1 && numberOfCannotComplete>=1) {
+                if (numberOfServiceAppointments > 1 && numberOfCanceled + numberOfCannotComplete == numberOfServiceAppointments) {
                     workOrderLineItem.Status = 'Cannot Complete';
                     continue;
                 }

--- a/force-app/main/fslStatusTransition/classes/HOT_WorkOrderLineItemStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_WorkOrderLineItemStatusHandler.cls
@@ -177,6 +177,10 @@ public without sharing class HOT_WorkOrderLineItemStatusHandler extends MyTrigge
                     workOrderLineItem.Status = 'Partially Complete';
                     continue;
                 }
+                if (numberOfServiceAppointments > 1 && numberOfCanceled >=1 && numberOfCannotComplete>=1) {
+                    workOrderLineItem.Status = 'Cannot Complete';
+                    continue;
+                }
             }
         }
     }


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2158

### **Hvorfor:** 
Om det er opprettet en arbeidsordre med 2 oppdrag, det ene settes til Avlyst og det andre settes til Udekket, status ute hos bestiller viser "Under behandling".

Avlyst+Udekket må gi statusen "Ikke ledig tolk" hos bestiller.
### **Hva er gjort:**
Når en bestilling har flere oppdrag (altså flere tolker), vil bestillingen få status "Ikke ledig tolk" om alle statusene til oppdrag er fylt ut, med en eller flere av både Cancelled og Cannot Complete. 

### **Testing:**

- [ ] Logg inn i comminity og opprett et oppdrag.
- [ ] Godkjenn forespørselen. Legg til 2 i antall tolker.
- [ ] Gå inn på et av oppdragene tilhørende og sett status til 'Cancelled'
- [ ] Status på workorderlineitem skal være 'Scheduled'.
- [ ] Gå inn på det andre oppdraget og sett status til 'Cannot complete'.
- [ ] Status skal nå være 'Cannot complete'.

- [ ] Lek litt rundt her og endre status til hva enn du vil. Det skal iallefall stå 'Cannot complete' alle oppdragene er enten full av minst 1 Cancelled og minst 1 Cannot complete (kun de to statusene. andre statuser kan overstyre).

- [ ] Lag også en forespørsel og velg enda flere tolker. Og lek litt rundt. 

<img width="1726" alt="Skjermbilde 2023-01-05 kl  10 42 09" src="https://user-images.githubusercontent.com/111959793/210749544-76744cf5-1b31-482e-93eb-8d7a0da279e2.png">
<img width="1703" alt="Skjermbilde 2023-01-05 kl  10 42 48" src="https://user-images.githubusercontent.com/111959793/210749679-9c515503-0d7c-4ce7-86c2-e8814ab578a7.png">

