### PR TITLE
Tolk 2191 - feil når formidler avlyser serie

### DIFF
--- a/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
@@ -173,7 +173,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
 
     private static void updateChildRecords(List<HOT_Request__c> changedRequests, String newStatus) {
         List<WorkOrder> workOrders = [
-            SELECT Status
+            SELECT Status, StartDate
             FROM WorkOrder
             WHERE
                 HOT_Request__c IN :changedRequests
@@ -184,7 +184,9 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         ];
 
         for (WorkOrder workOrder : workOrders) {
-            workOrder.Status = newStatus;
+            if(workOrder.StartDate > Datetime.now()){
+                workOrder.Status = newStatus;
+            }
         }
         if (workOrders.size() > 0) {
             update workOrders;


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2191

Nå vil ikke oppdrag som har startet få endret status (til avlyst) når formidler avlyser seriebestilling.

### Testing

- [ ] Opprett seriebestilling i community og sett starttidsspunkt om 1 minutt, og gjenta noen dager.
- [ ] Imens gå i salseforce og godkjenn forespørselen.
- [ ] Sett en eller annen status på det første oppdraget. Og andre statuser på de andre oppdragene.
- [ ] Når startidspunktet er forbigått, gå til forespørselen og avlys den. 
- [ ] Nå skal altså alle oppdrag/workorder fått status avlyst, bortsett fra den som har gått forbi i tid.