### PR TITLE
Tolk 2125 - Endre status på forespørsel til udekket når alle oppdrag er frigitt til frilans eller alle arbeidsordre er åpen

### DIFF
--- a/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
@@ -191,7 +191,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         ];
 
         for (WorkOrder workOrder : workOrders) {
-            if(workOrder.StartDate > Datetime.now()){
+            if (workOrder.StartDate > Datetime.now()) {
                 workOrder.Status = newStatus;
             }
         }
@@ -200,46 +200,59 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         }
     }
     private static void updateServiceAppointments(List<HOT_Request__c> changedRequests, String newStatus) {
-        List<ServiceAppointment> serviceAppointments = [SELECT Id, Status, HOT_Request__c FROM ServiceAppointment WHERE HOT_Request__c IN :changedRequests];
+        List<ServiceAppointment> serviceAppointments = [
+            SELECT Id, Status, HOT_Request__c
+            FROM ServiceAppointment
+            WHERE HOT_Request__c IN :changedRequests
+        ];
         Map<Id, ServiceAppointment> serviceAppointmentMap = new Map<Id, ServiceAppointment>(serviceAppointments);
 
-        List<WorkOrder> workOrders = [SELECT Id, Status, HOT_Request__c FROM WorkOrder WHERE HOT_Request__c IN :changedRequests];
+        List<WorkOrder> workOrders = [
+            SELECT Id, Status, HOT_Request__c
+            FROM WorkOrder
+            WHERE HOT_Request__c IN :changedRequests
+        ];
         Map<Id, WorkOrder> workOrderMap = new Map<Id, WorkOrder>(workOrders);
 
-        for(HOT_Request__c request : changedRequests){
-        Integer numberOfReleasedToFreelance = 0;
-        Integer numberOfServiceAppointments = 0;
+        for (HOT_Request__c request : changedRequests) {
+            Integer numberOfReleasedToFreelance = 0;
+            Integer numberOfServiceAppointments = 0;
             for (Id saId : serviceAppointmentMap.keySet()) {
                 ServiceAppointment sa = serviceAppointmentMap.get(saId);
-                if(sa.HOT_Request__c == request.Id) {
-                    if(sa.Status=='Released to Freelance' || sa.Status=='Cannot Complete'){
+                if (sa.HOT_Request__c == request.Id) {
+                    if (sa.Status == 'Released to Freelance' || sa.Status == 'Cannot Complete') {
                         numberOfReleasedToFreelance++;
                     }
                     numberOfServiceAppointments++;
                 }
             }
-        Integer numberOfOpenWorkOrders = 0;
-        Integer numberOfWorkOrders = 0;
+            Integer numberOfOpenWorkOrders = 0;
+            Integer numberOfWorkOrders = 0;
             for (Id woId : workOrderMap.keySet()) {
                 WorkOrder wo = workOrderMap.get(woId);
-                if(wo.HOT_Request__c == request.Id) {
-                    if(wo.Status=='New' || wo.Status=='Cannot Complete'){
+                if (wo.HOT_Request__c == request.Id) {
+                    if (wo.Status == 'New' || wo.Status == 'Cannot Complete') {
                         numberOfOpenWorkOrders++;
                     }
                     numberOfWorkOrders++;
                 }
             }
 
-            if(numberOfServiceAppointments == numberOfReleasedToFreelance || numberOfOpenWorkOrders == numberOfWorkOrders){
+            if (
+                numberOfServiceAppointments == numberOfReleasedToFreelance ||
+                numberOfOpenWorkOrders == numberOfWorkOrders
+            ) {
                 for (Id saId : serviceAppointmentMap.keySet()) {
                     ServiceAppointment sa = serviceAppointmentMap.get(saId);
-                    if(sa.HOT_Request__c == request.Id) {
+                    if (sa.HOT_Request__c == request.Id) {
                         sa.Status = 'Cannot Complete';
                     }
                 }
                 update serviceAppointmentMap.values();
             } else {
-                request.addError('Alle oppdrag må være Frigitt til frilans, eller alle arbeidsordre må være Åpen for at du skal kunne sette hele forespørselen til Udekket.');
+                request.addError(
+                    'Alle oppdrag må være Frigitt til frilans, eller alle arbeidsordre må være Åpen for at du skal kunne sette hele forespørselen til Udekket.'
+                );
             }
         }
     }

--- a/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
@@ -21,6 +21,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         List<HOT_Request__c> avlystRequests = new List<HOT_Request__c>();
         List<HOT_Request__c> annullertRequests = new List<HOT_Request__c>();
         List<HOT_Request__c> avslaattRequests = new List<HOT_Request__c>();
+        List<HOT_Request__c> cannotCompleteRequests = new List<HOT_Request__c>();
 
         for (HOT_Request__c request : (List<HOT_Request__c>) records) {
             // Filter for Avlyst requests
@@ -37,6 +38,9 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
             if (request.Status__c != triggerOldMap.get(request.Id).get('Status__c') && request.Status__c == 'Avslått') {
                 avslaattRequests.add(request);
             }
+            if (request.Status__c != triggerOldMap.get(request.Id).get('Status__c') && request.Status__c == 'Udekket') {
+                cannotCompleteRequests.add(request);
+            }
         }
         if (avlystRequests.size() > 0) {
             updateChildRecords(avlystRequests, 'Canceled');
@@ -46,6 +50,9 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         }
         if (avslaattRequests.size() > 0) {
             updateChildRecords(avslaattRequests, 'Denied');
+        }
+        if (cannotCompleteRequests.size() > 0) {
+            updateServiceAppointments(cannotCompleteRequests, 'Cannot Complete');
         }
     }
 
@@ -190,6 +197,35 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         }
         if (workOrders.size() > 0) {
             update workOrders;
+        }
+    }
+    private static void updateServiceAppointments(List<HOT_Request__c> changedRequests, String newStatus) {
+        List<ServiceAppointment> serviceAppointments = [SELECT Id, Status, HOT_Request__c FROM ServiceAppointment WHERE HOT_Request__c IN :changedRequests];
+        Map<Id, ServiceAppointment> serviceAppointmentMap = new Map<Id, ServiceAppointment>(serviceAppointments);
+
+        for(HOT_Request__c request : changedRequests){
+        Integer numberOfReleasedToFreelance = 0;
+        Integer numberOfServiceAppointments = 0;
+            for (Id saId : serviceAppointmentMap.keySet()) {
+                ServiceAppointment sa = serviceAppointmentMap.get(saId);
+                if(sa.HOT_Request__c == request.Id) {
+                    if(sa.Status=='Released to Freelance'){
+                        numberOfReleasedToFreelance++;
+                    }
+                    numberOfServiceAppointments++;
+                }
+            }
+            if(numberOfServiceAppointments == numberOfReleasedToFreelance){
+                for (Id saId : serviceAppointmentMap.keySet()) {
+                    ServiceAppointment sa = serviceAppointmentMap.get(saId);
+                    if(sa.HOT_Request__c == request.Id) {
+                        sa.Status = 'Cannot Complete';
+                    }
+                }
+                update serviceAppointmentMap.values();
+            } else {
+                request.addError('Alle oppdrag må være Frigitt til frilans for at du skal kunne sette hele forespørselen til Udekket.');
+            }
         }
     }
 }

--- a/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
@@ -203,6 +203,9 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
         List<ServiceAppointment> serviceAppointments = [SELECT Id, Status, HOT_Request__c FROM ServiceAppointment WHERE HOT_Request__c IN :changedRequests];
         Map<Id, ServiceAppointment> serviceAppointmentMap = new Map<Id, ServiceAppointment>(serviceAppointments);
 
+        List<WorkOrder> workOrders = [SELECT Id, Status, HOT_Request__c FROM WorkOrder WHERE HOT_Request__c IN :changedRequests];
+        Map<Id, WorkOrder> workOrderMap = new Map<Id, WorkOrder>(workOrders);
+
         for(HOT_Request__c request : changedRequests){
         Integer numberOfReleasedToFreelance = 0;
         Integer numberOfServiceAppointments = 0;
@@ -215,7 +218,19 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
                     numberOfServiceAppointments++;
                 }
             }
-            if(numberOfServiceAppointments == numberOfReleasedToFreelance){
+        Integer numberOfOpenWorkOrders = 0;
+        Integer numberOfWorkOrders = 0;
+            for (Id woId : workOrderMap.keySet()) {
+                WorkOrder wo = workOrderMap.get(woId);
+                if(wo.HOT_Request__c == request.Id) {
+                    if(wo.Status=='New'){
+                        numberOfOpenWorkOrders++;
+                    }
+                    numberOfWorkOrders++;
+                }
+            }
+
+            if(numberOfServiceAppointments == numberOfReleasedToFreelance || numberOfOpenWorkOrders == numberOfWorkOrders){
                 for (Id saId : serviceAppointmentMap.keySet()) {
                     ServiceAppointment sa = serviceAppointmentMap.get(saId);
                     if(sa.HOT_Request__c == request.Id) {
@@ -224,7 +239,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
                 }
                 update serviceAppointmentMap.values();
             } else {
-                request.addError('Alle oppdrag må være Frigitt til frilans for at du skal kunne sette hele forespørselen til Udekket.');
+                request.addError('Alle oppdrag må være Frigitt til frilans, eller alle arbeidsordre må være Åpen for at du skal kunne sette hele forespørselen til Udekket.');
             }
         }
     }

--- a/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
+++ b/force-app/main/fslStatusTransition/classes/HOT_RequestStatusHandler.cls
@@ -212,7 +212,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
             for (Id saId : serviceAppointmentMap.keySet()) {
                 ServiceAppointment sa = serviceAppointmentMap.get(saId);
                 if(sa.HOT_Request__c == request.Id) {
-                    if(sa.Status=='Released to Freelance'){
+                    if(sa.Status=='Released to Freelance' || sa.Status=='Cannot Complete'){
                         numberOfReleasedToFreelance++;
                     }
                     numberOfServiceAppointments++;
@@ -223,7 +223,7 @@ public without sharing class HOT_RequestStatusHandler extends MyTriggers {
             for (Id woId : workOrderMap.keySet()) {
                 WorkOrder wo = workOrderMap.get(woId);
                 if(wo.HOT_Request__c == request.Id) {
-                    if(wo.Status=='New'){
+                    if(wo.Status=='New' || wo.Status=='Cannot Complete'){
                         numberOfOpenWorkOrders++;
                     }
                     numberOfWorkOrders++;

--- a/force-app/main/triggers/classes/HOT_RequestHandlerTest.cls
+++ b/force-app/main/triggers/classes/HOT_RequestHandlerTest.cls
@@ -408,4 +408,147 @@ private class HOT_RequestHandlerTest {
         System.assertNotEquals('Oslo', requester[0].MeetingPostalCity__c, 'Both adresses was changed to the same');
         System.assertNotEquals('0166', requester[0].MeetingPostalCode__c, 'Both adresses was changed to the same');
     }
+   @isTest
+    public static void shouldOnlyChangeStatusToCannotCompleteIfAllSAIsReleased() {
+     WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        insert request;
+        WorkOrder workOrder1 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder1;
+        WorkOrder workOrder2 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder2;
+        WorkOrderLineItem workOrderLineItem1 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder1, workType);
+        insert workOrderLineItem1;
+        WorkOrderLineItem workOrderLineItem2 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder2, workType);
+        insert workOrderLineItem2;
+        ServiceAppointment sa1 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem1);
+        sa1.HOT_Request__c = request.Id;
+        ServiceAppointment sa2 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem2);
+        sa2.HOT_Request__c = request.Id;
+        insert sa1;
+        insert sa2;
+        
+        sa1.Status = 'Released to Freelance';
+        sa2.Status = 'Released to Freelance';
+        update sa1;
+        update sa2;
+        update new List<WorkOrder>{ workOrder1, workOrder2 };
+
+        request.Status__c = 'Udekket';
+        update request;
+        request = [SELECT Status__c FROM HOT_Request__c WHERE Id = :request.Id];
+
+        System.assertEquals('Udekket', request.Status__c, 'Status on the request did not update to correct value');
+    }
+    @isTest
+    public static void statusIsNotSupposedToChangeBecauseSAIsNotReleasedToFreelance() {
+     WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        insert request;
+        WorkOrder workOrder1 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder1;
+        WorkOrder workOrder2 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder2;
+        WorkOrderLineItem workOrderLineItem1 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder1, workType);
+        insert workOrderLineItem1;
+        WorkOrderLineItem workOrderLineItem2 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder2, workType);
+        insert workOrderLineItem2;
+        ServiceAppointment sa1 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem1);
+        sa1.HOT_Request__c = request.Id;
+        ServiceAppointment sa2 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem2);
+        sa2.HOT_Request__c = request.Id;
+        insert sa1;
+        insert sa2;
+        request.Status__c = 'Godkjent';
+        update request;
+        sa1.Status = 'Dispatched';
+        sa2.Status = 'Released to Freelance';
+        update sa1;
+        update sa2;
+        update new List<WorkOrder>{ workOrder1, workOrder2 };
+
+        request.Status__c = 'Udekket';
+        try{
+            update request;
+        }
+        catch(Exception e){
+            Boolean expectedException =  e.getMessage().contains('Alle oppdrag må være Frigitt til frilans, eller alle arbeidsordre må være Åpen for at du skal kunne sette hele forespørselen til Udekket.') ? true : false;
+            System.AssertEquals(expectedException, true);
+} 
+        
+        
+    }
+     @isTest
+    public static void statusShouldChangeWhenAllWorkOrdersAreSetToNew() {
+     WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        insert request;
+        WorkOrder workOrder1 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder1;
+        WorkOrder workOrder2 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder2;
+        WorkOrderLineItem workOrderLineItem1 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder1, workType);
+        insert workOrderLineItem1;
+        WorkOrderLineItem workOrderLineItem2 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder2, workType);
+        insert workOrderLineItem2;
+        ServiceAppointment sa1 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem1);
+        sa1.HOT_Request__c = request.Id;
+        ServiceAppointment sa2 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem2);
+        sa2.HOT_Request__c = request.Id;
+        insert sa1;
+        insert sa2;
+        request.Status__c = 'Godkjent';
+        update request;
+        workOrder1.Status = 'New';
+        workOrder2.Status = 'New';
+        update workOrder1;
+        update workOrder2;
+
+        request.Status__c = 'Udekket';
+        update request;
+        request = [SELECT Status__c FROM HOT_Request__c WHERE Id = :request.Id];
+
+        System.assertEquals('Udekket', request.Status__c, 'Status on the request was supposed to be changed');
+    }
+      @isTest
+    public static void statusShouldNotChangeWhenAllWorkOrdersAreNotSetNew() {
+
+        //feil i den her
+     WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        insert request;
+        WorkOrder workOrder1 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder1;
+        WorkOrder workOrder2 = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder2;
+        WorkOrderLineItem workOrderLineItem1 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder1, workType);
+        insert workOrderLineItem1;
+        WorkOrderLineItem workOrderLineItem2 = HOT_TestDataFactory.createWorkOrderLineItem(workOrder2, workType);
+        insert workOrderLineItem2;
+        ServiceAppointment sa1 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem1);
+        sa1.HOT_Request__c = request.Id;
+        ServiceAppointment sa2 = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem2);
+        sa2.HOT_Request__c = request.Id;
+        insert sa1;
+        insert sa2;
+        request.Status__c = 'Godkjent';
+        update request;
+        workOrder1.Status = 'Scheduled';
+        workOrder2.Status = 'New';
+        update workOrder1;
+        update workOrder2;
+
+        request.Status__c = 'Udekket';
+         try{
+            update request;
+        }
+        catch(Exception e){
+            Boolean expectedException =  e.getMessage().contains('Alle oppdrag må være Frigitt til frilans, eller alle arbeidsordre må være Åpen for at du skal kunne sette hele forespørselen til Udekket.') ? true : false;
+            System.AssertEquals(expectedException, true);
+} 
+    }
 }


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2125
### HVORFOR
Som formidler ønsker jeg at status på WO og SA skal oppdatere seg om F settes til status Udekket.
Om alle Arbeidsordrer og Oppdrag har status Åpen eller Frigitt til frilanstolk, skal formidler kunne sette Forespørselen til Udekket, hvor da status på arbeidsordre(r) og oppdrag automatisk oppdateres.

### Testing

- [ ] For eksempel lag en seriebestilling.
- [ ] Godkjenn seriebestillingen.
- [ ] 
