### PR TITLE
Tolk 2187 v2- Popup vindu med informasjon på alle listene for frilanstolk. Nå inkludert filene :)

### DIFF
--- a/force-app/main/freelanceCommunity/classes/HOT_InterestedResourcesListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_InterestedResourcesListController.cls
@@ -89,7 +89,15 @@ public without sharing class HOT_InterestedResourcesListController {
             update interestedResource;
         }
     }
-
+     @AuraEnabled
+    public static HOT_InterestedResource__c getComments(String interestedResourceId) {
+        HOT_InterestedResource__c interestedResource = [
+            SELECT Id, Comments__c
+            FROM HOT_InterestedResource__c
+            WHERE Id = :interestedResourceId
+        ];
+        return interestedResource;
+    }
     @AuraEnabled
     public static void dispatcherReadComment(Id recordId) {
         HOT_InterestedResource__c interestedResource = [

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.css
@@ -27,3 +27,23 @@ span {
         margin: 5vw 0;
     }
 }
+.comments-dialog-container {
+    all: unset;
+    background-color: #fff;
+    display: block;
+    padding: 5rem;
+    border-radius: 4px;
+    position: relative;
+    flex-grow: 0;
+    overflow-x: auto;
+    max-height: 100%;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    z-index: 1010;
+    max-width: 432px;
+    max-height: 75%;
+    width: 100%;
+}
+.hidden {
+    display: none;
+}

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.html
@@ -1,63 +1,8 @@
 <template>
     <div class="main-content">
-        <div if:true={isDetails}>
-            <div class="record-details-container">
-                <p>Oppdrag: <span>{interestedResource.AppointmentNumber__c}</span></p>
-                <p>Tid: <span>{interestedResource.StartAndEndDate}</span></p>
-                <p>Adresse: <span>{interestedResource.ServiceAppointmentAddress__c}</span></p>
-                <p>Tolkemetode: <span>{interestedResource.WorkTypeName__c}</span></p>
-                <p>Oppdragstype: <span>{interestedResource.AssignmentType__c}</span></p>
-                <p>Status: <span>{interestedResource.Status__c}</span></p>
-                <p>Antall påmeldte: <span>{interestedResource.NumberOfInterestedResources__c}</span></p>
-                <p>Frist dato: <span>{interestedResource.AppointmentDeadlineDate__c}</span></p>
-                <p>Region: <span>{interestedResource.AppointmentServiceTerritory__c}</span></p>
-                <p>Tema: <span>{interestedResource.ServiceAppointmentFreelanceSubject__c}</span></p>
-                <p if:true={interestedResource.WorkOrderCanceledDate__c}>
-                    Avlyst dato: <span>{interestedResource.WorkOrderCanceledDate__c}</span>
-                </p>
-                <p if:true={interestedResource.HOT_TermsOfAgreement__c}>
-                    Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>
-                </p>
-            </div>
-            <c-button
-                disabled={isNotRetractable}
-                onbuttonclick={retractInterest}
-                button-styling="Primary"
-                type="Submit"
-                button-label="Tilbaketrekk interesse"
-            >
-            </c-button>
-            <section style="margin-bottom: 2rem">
-                <div style="padding: 1rem">
-                    <br />
-                    <div>
-                        <h2 class="typo-undertittel ikke-sensitive-opplysninger__label">Dialog med formidler</h2>
-                        <template iterator:it={prevComments}>
-                            <p class="typo-normal" key={it.value}>{it.value}</p>
-                            <p style="color: transparent" key={it.value}>.</p>
-                        </template>
-                    </div>
-                    <lightning-textarea
-                        label="Legg til ny kommentar"
-                        style="margin-bottom: 1rem"
-                        class="newComment"
-                        name="newComment"
-                    >
-                    </lightning-textarea>
-                    <lightning-button
-                        onclick={sendComment}
-                        class="slds-m-left_x-small"
-                        variant="brand"
-                        type="submit"
-                        label="Send inn"
-                    >
-                    </lightning-button>
-                </div>
-            </section>
-        </div>
         <div if:false={noInterestedResources}>
             <c-table
-                if:false={isDetails}
+                if:false={noInterestedResources}
                 records={records}
                 columns={columns}
                 onrowclick={goToRecordDetails}
@@ -67,6 +12,84 @@
         <div if:true={noInterestedResources} style="text-align: center">
             <br />
             Du har ingen påmeldte oppdrag.
+        </div>
+        <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open modal__overlay serviceAppointmentDetails hidden"
+            style="z-index: 9999; background-color: rgba(50, 65, 79, 0.8)"
+            tabindex="-1"
+            aria-label="Informasjon om oppdrag"
+        >
+            <div
+                class="ReactModal__Content ReactModal__Content--after-open navno-dekorator comments-dialog-container"
+                role="dialog"
+                aria-labelledby="comment-header-id"
+            >
+                <section>
+                    <div>
+                        <h2 class="typo-undertittel">Informasjon om oppdraget:</h2>
+                    </div>
+                    <div if:true={isDetails}>
+                        <div class="record-details-container">
+                            <p>Oppdrag: <span>{interestedResource.AppointmentNumber__c}</span></p>
+                            <p>Tid: <span>{interestedResource.StartAndEndDate}</span></p>
+                            <p>Adresse: <span>{interestedResource.ServiceAppointmentAddress__c}</span></p>
+                            <p>Tolkemetode: <span>{interestedResource.WorkTypeName__c}</span></p>
+                            <p>Oppdragstype: <span>{interestedResource.AssignmentType__c}</span></p>
+                            <p>Status: <span>{interestedResource.Status__c}</span></p>
+                            <p>Antall påmeldte: <span>{interestedResource.NumberOfInterestedResources__c}</span></p>
+                            <p>Frist dato: <span>{interestedResource.AppointmentDeadlineDate__c}</span></p>
+                            <p>Region: <span>{interestedResource.AppointmentServiceTerritory__c}</span></p>
+                            <p>Tema: <span>{interestedResource.ServiceAppointmentFreelanceSubject__c}</span></p>
+                            <p if:true={interestedResource.WorkOrderCanceledDate__c}>
+                                Avlyst dato: <span>{interestedResource.WorkOrderCanceledDate__c}</span>
+                            </p>
+                            <p if:true={interestedResource.HOT_TermsOfAgreement__c}>
+                                Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>
+                            </p>
+                        </div>
+                        <c-button
+                            disabled={isNotRetractable}
+                            onbuttonclick={retractInterest}
+                            button-styling="Primary"
+                            type="Submit"
+                            button-label="Tilbaketrekk interesse"
+                        >
+                        </c-button>
+                        <section style="margin-bottom: 2rem">
+                            <div style="padding: 1rem">
+                                <br />
+                                <div>
+                                    <h2 class="typo-undertittel ikke-sensitive-opplysninger__label">
+                                        Dialog med formidler
+                                    </h2>
+                                    <template iterator:it={prevComments}>
+                                        <p class="typo-normal" key={it.value}>{it.value}</p>
+                                        <p style="color: transparent" key={it.value}>.</p>
+                                    </template>
+                                </div>
+                                <lightning-textarea
+                                    label="Legg til ny kommentar"
+                                    style="margin-bottom: 1rem"
+                                    class="newComment"
+                                    name="newComment"
+                                >
+                                </lightning-textarea>
+                                <lightning-button
+                                    onclick={sendComment}
+                                    class="slds-m-left_x-small"
+                                    variant="brand"
+                                    type="submit"
+                                    label="Send inn"
+                                >
+                                </lightning-button>
+                            </div>
+                        </section>
+                    </div>
+                </section>
+                <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
+                    <span class="text-hide">Lukk</span>
+                </button>
+            </div>
         </div>
     </div>
 </template>

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -8,6 +8,7 @@ import { defaultFilters, compare } from './filters';
 import { formatRecord } from 'c/datetimeFormatter';
 import addComment from '@salesforce/apex/HOT_InterestedResourcesListController.addComment';
 import readComment from '@salesforce/apex/HOT_InterestedResourcesListController.readComment';
+import getComments from '@salesforce/apex/HOT_InterestedResourcesListController.getComments';
 
 export default class Hot_interestedResourcesList extends LightningElement {
     @track columns = [];
@@ -104,8 +105,8 @@ export default class Hot_interestedResourcesList extends LightningElement {
 
     refresh() {
         this.filters = defaultFilters();
-        this.goToRecordDetails({ detail: { Id: this.recordId } });
-        this.sendRecords();
+        //this.goToRecordDetails({ detail: { Id: this.recordId } });
+        //this.sendRecords();
         this.sendFilters();
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
     }
@@ -126,11 +127,10 @@ export default class Hot_interestedResourcesList extends LightningElement {
     isSeries = false;
     showTable = true;
     goToRecordDetails(result) {
-        window.scrollTo(0, 0);
+        this.template.querySelector('.serviceAppointmentDetails').classList.remove('hidden');
+        this.template.querySelector('.serviceAppointmentDetails').focus();
         this.interestedResource = undefined;
         let recordId = result.detail.Id;
-        console.log(this.recordId);
-        console.log(result.detail.Id);
         this.recordId = recordId;
         this.isDetails = !!this.recordId;
         for (let interestedResource of this.records) {
@@ -141,7 +141,6 @@ export default class Hot_interestedResourcesList extends LightningElement {
         this.isNotRetractable = this.interestedResource?.Status__c !== 'Påmeldt';
         this.fixComments();
         this.updateURL();
-        this.sendDetail();
         if (this.interestedResource?.IsNewComment__c) {
             readComment({ interestedResourceId: this.interestedResource?.Id });
         }
@@ -171,6 +170,8 @@ export default class Hot_interestedResourcesList extends LightningElement {
         let newComment = this.template.querySelector('.newComment').value;
         addComment({ interestedResourceId, newComment }).then(() => {
             refreshApex(this.wiredInterestedResourcesResult);
+            this.template.querySelector('.newComment').value = '';
+            this.fixComments();
         });
     }
     filteredRecordsLength = 0;
@@ -200,17 +201,24 @@ export default class Hot_interestedResourcesList extends LightningElement {
 
     @track prevComments = '';
     fixComments() {
-        if (this.interestedResource?.Comments__c != undefined) {
-            this.prevComments = this.interestedResource?.Comments__c.split('\n\n');
-        } else {
-            this.prevComments = '';
-        }
+        getComments({ interestedResourceId: this.recordId }).then((result) => {
+            console.log(result.Comments__c);
+            if (result.Comments__c != undefined || result.Comments__c != '') {
+                this.prevComments = result.Comments__c.split('\n\n');
+            } else {
+                this.prevComments = '';
+            }
+        });
     }
     isNotRetractable = false;
     retractInterest() {
         retractInterest({ interestedResourceId: this.interestedResource.Id }).then(() => {
             refreshApex(this.wiredInterestedResourcesResult);
             this.interestedResource.Status__c = 'Tilbaketrukket påmelding';
+            this.isNotRetractable = true;
         });
+    }
+    closeModal() {
+        this.template.querySelector('.serviceAppointmentDetails').classList.add('hidden');
     }
 }

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.css
@@ -34,3 +34,23 @@ span {
     margin: 2rem 0;
     max-width: 500px;
 }
+.comments-dialog-container {
+    all: unset;
+    background-color: #fff;
+    display: block;
+    padding: 5rem;
+    border-radius: 4px;
+    position: relative;
+    flex-grow: 0;
+    overflow-x: auto;
+    max-height: 100%;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    z-index: 1010;
+    max-width: 432px;
+    max-height: 75%;
+    width: 100%;
+}
+.hidden {
+    display: none;
+}

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
@@ -1,72 +1,98 @@
 <template>
     <div class="main-content">
-        <div if:true={isDetails}>
-            <div class="record-details-container">
-                <p>Oppdragsnummer: <span>{serviceAppointment.AppointmentNumber}</span></p>
-                <p>Tema: <span>{serviceAppointment.Subject}</span></p>
-                <p>Tid: <span>{serviceAppointment.StartAndEndDate}</span></p>
-                <p>Faktisk start: <span>{serviceAppointment.ActualStartTime}</span></p>
-                <p>Faktisk slutt: <span>{serviceAppointment.ActualEndTime}</span></p>
-                <p>Adresse: <span>{serviceAppointment.HOT_AddressFormated__c}</span></p>
-                <p>Region: <span>{serviceAppointment.HOT_ServiceTerritoryName__c}</span></p>
-                <p>Status: <span>{serviceAppointment.Status}</span></p>
-                <p>Haptisk kommunikasjon: <span>{serviceAppointment.HOT_HapticCommunication__c}</span></p>
-                <p if:true={serviceAppointment.HOT_Escort__c}>
-                    Ledsaging: <span>{serviceAppointment.HOT_Escort__c}</span>
-                </p>
-                <p if:true={serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}>
-                    Vedtak: <span>{serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}</span>
-                </p>
-                <p>Tolkemetode: <span>{serviceAppointment.HOT_WorkTypeName__c}</span></p>
-                <p if:true={interestedResource}>
-                    Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>
-                </p>
-                <p>Tilleggsopplysninger: <span>{serviceAppointment.Description}</span></p>
-                <p>Formidler: <span>{serviceAppointment.HOT_Dispatcher__c}</span></p>
-                <div class="files-container">
-                    <c-record-files-with-sharing
-                        record-id={serviceAppointment.Id}
-                        is-get-all="true"
-                        is-delete-option="false"
-                        title="Vedlegg"
-                        delete-file-on-button-click="false"
-                    ></c-record-files-with-sharing>
-                </div>
-            </div>
-            <div>
-                <c-button
-                    disabled={isEditButtonDisabled}
-                    hidden={isEditButtonHidden}
-                    onbuttonclick={changeStatus}
-                    button-styling="Primary"
-                    type="Submit"
-                    button-label="Endre status"
-                >
-                </c-button>
-                <c-button
-                    hidden={isCancelButtonHidden}
-                    onbuttonclick={cancelStatusFlow}
-                    button-styling="Secondary"
-                    type="Submit"
-                    style="margin: 2rem 0"
-                    button-label="Avbryt"
-                >
-                </c-button>
-            </div>
-        </div>
-        <div if:true={isflow} class="flow-container">
-            <lightning-flow
-                flow-api-name="HOT_ChangeServiceAppointmentStatus"
-                flow-input-variables={flowVariables}
-                onstatuschange={handleStatusChange}
-            ></lightning-flow>
-        </div>
         <div if:false={noServiceAppointments}>
-            <c-table if:false={isDetails} records={records} columns={columns} onrowclick={goToRecordDetails}></c-table>
+            <c-table
+                if:false={noServiceAppointments}
+                records={records}
+                columns={columns}
+                onrowclick={goToRecordDetails}
+            ></c-table>
         </div>
         <div if:true={noServiceAppointments} style="text-align: center">
             <br />
             Du har ingen oppdrag.
+        </div>
+        <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open modal__overlay serviceAppointmentDetails hidden"
+            style="z-index: 9999; background-color: rgba(50, 65, 79, 0.8)"
+            tabindex="-1"
+            aria-label="Informasjon om oppdrag"
+        >
+            <div
+                class="ReactModal__Content ReactModal__Content--after-open navno-dekorator comments-dialog-container"
+                role="dialog"
+                aria-labelledby="comment-header-id"
+            >
+                <section>
+                    <div>
+                        <h2 class="typo-undertittel">Informasjon om oppdraget:</h2>
+                    </div>
+                    <div if:true={isDetails}>
+                        <div class="record-details-container">
+                            <p>Oppdragsnummer: <span>{serviceAppointment.AppointmentNumber}</span></p>
+                            <p>Tema: <span>{serviceAppointment.Subject}</span></p>
+                            <p>Tid: <span>{serviceAppointment.StartAndEndDate}</span></p>
+                            <p>Faktisk start: <span>{serviceAppointment.ActualStartTime}</span></p>
+                            <p>Faktisk slutt: <span>{serviceAppointment.ActualEndTime}</span></p>
+                            <p>Adresse: <span>{serviceAppointment.HOT_AddressFormated__c}</span></p>
+                            <p>Region: <span>{serviceAppointment.HOT_ServiceTerritoryName__c}</span></p>
+                            <p>Status: <span>{serviceAppointment.Status}</span></p>
+                            <p>Haptisk kommunikasjon: <span>{serviceAppointment.HOT_HapticCommunication__c}</span></p>
+                            <p if:true={serviceAppointment.HOT_Escort__c}>
+                                Ledsaging: <span>{serviceAppointment.HOT_Escort__c}</span>
+                            </p>
+                            <p if:true={serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}>
+                                Vedtak: <span>{serviceAppointment.HOT_DegreeOfHearingAndVisualImpairment__c}</span>
+                            </p>
+                            <p>Tolkemetode: <span>{serviceAppointment.HOT_WorkTypeName__c}</span></p>
+                            <p if:true={interestedResource}>
+                                Avtalte betingelser: <span>{interestedResource.HOT_TermsOfAgreement__c}</span>
+                            </p>
+                            <p>Tilleggsopplysninger: <span>{serviceAppointment.Description}</span></p>
+                            <p>Formidler: <span>{serviceAppointment.HOT_Dispatcher__c}</span></p>
+                            <div class="files-container">
+                                <c-record-files-with-sharing
+                                    record-id={serviceAppointment.Id}
+                                    is-get-all="true"
+                                    is-delete-option="false"
+                                    title="Vedlegg"
+                                    delete-file-on-button-click="false"
+                                ></c-record-files-with-sharing>
+                            </div>
+                        </div>
+                        <div>
+                            <c-button
+                                disabled={isEditButtonDisabled}
+                                hidden={isEditButtonHidden}
+                                onbuttonclick={changeStatus}
+                                button-styling="Primary"
+                                type="Submit"
+                                button-label="Endre status"
+                            >
+                            </c-button>
+                            <c-button
+                                hidden={isCancelButtonHidden}
+                                onbuttonclick={cancelStatusFlow}
+                                button-styling="Secondary"
+                                type="Submit"
+                                style="margin: 2rem 0"
+                                button-label="Avbryt"
+                            >
+                            </c-button>
+                        </div>
+                        <div if:true={isflow} class="flow-container">
+                            <lightning-flow
+                                flow-api-name="HOT_ChangeServiceAppointmentStatus"
+                                flow-input-variables={flowVariables}
+                                onstatuschange={handleStatusChange}
+                            ></lightning-flow>
+                        </div>
+                    </div>
+                </section>
+                <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
+                    <span class="text-hide">Lukk</span>
+                </button>
+            </div>
         </div>
     </div>
 </template>

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -104,7 +104,6 @@ export default class Hot_myServiceAppointments extends LightningElement {
 
     refresh() {
         this.filters = defaultFilters();
-        this.goToRecordDetails({ detail: { Id: this.recordId } });
         this.sendRecords();
         this.sendFilters();
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
@@ -125,7 +124,8 @@ export default class Hot_myServiceAppointments extends LightningElement {
     isSeries = false;
     showTable = true;
     goToRecordDetails(result) {
-        window.scrollTo(0, 0);
+        this.template.querySelector('.serviceAppointmentDetails').classList.remove('hidden');
+        this.template.querySelector('.serviceAppointmentDetails').focus();
         let today = new Date();
         this.serviceAppointment = undefined;
         this.interestedResource = undefined;
@@ -145,7 +145,7 @@ export default class Hot_myServiceAppointments extends LightningElement {
             }
         }
         this.updateURL();
-        this.sendDetail();
+        //this.sendDetail();
     }
 
     @api recordId;
@@ -213,6 +213,9 @@ export default class Hot_myServiceAppointments extends LightningElement {
                 value: this.recordId
             }
         ];
+    }
+    closeModal() {
+        this.template.querySelector('.serviceAppointmentDetails').classList.add('hidden');
     }
     handleStatusChange(event) {
         console.log('handleStatusChange', event.detail);

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
@@ -1,37 +1,8 @@
 <template>
     <div class="main-content">
-        <div if:true={isDetails}>
-            <div class="record-details-container">
-                <p>Oppdragsnummer: <span>{serviceAppointment.HOT_ServiceAppointmentNumber__c}</span></p>
-                <p>Tid: <span>{serviceAppointment.StartAndEndDate}</span></p>
-                <p>Tema: <span>{serviceAppointment.HOT_FreelanceSubject__c}</span></p>
-                <p>Adresse: <span>{serviceAppointment.HOT_AddressFormated__c}</span></p>
-                <p>Tolkemetode: <span>{serviceAppointment.HOT_WorkTypeName__c}</span></p>
-                <p>Frigitt av: <span>{serviceAppointment.HOT_ReleasedBy__c}</span></p>
-                <p>Frigitt dato: <span>{serviceAppointment.ReleaseDate}</span></p>
-                <p>Antall påmeldte: <span>{serviceAppointment.HOT_NumberOfInterestedResources__c}</span></p>
-                <p>Region: <span>{serviceAppointment.HOT_ServiceTerritoryName__c}</span></p>
-                <p>Oppdragstype: <span>{serviceAppointment.HOT_AssignmentType__c}</span></p>
-                <p>Frist dato: <span>{serviceAppointment.HOT_DeadlineDate__c}</span></p>
-                <br />
-            </div>
-            <div if:true={isSeries}>
-                <c-button
-                    button-styling="primary"
-                    button-label="Meld interesse til alle oppdrag i serien"
-                    aria-label="Meld interesse til alle oppdrag i serien"
-                    onbuttonclick={sendInterestSeries}
-                    desktop-style="width: 20rem; justify-content: center; margin-bottom: 1rem;"
-                    mobile-style="width: 100%; justify-content: center; margin-bottom: 1rem;"
-                    title="Meld interesse til alle oppdrag i serien"
-                >
-                </c-button>
-                <c-table records={seriesRecords} columns={columns} onrowclick={goToRecordDetails}></c-table>
-            </div>
-        </div>
         <div if:false={noServiceAppointments}>
             <c-table
-                if:false={isDetails}
+                if:false={noServiceAppointments}
                 records={records}
                 columns={columns}
                 onrowclick={goToRecordDetails}
@@ -158,6 +129,56 @@
                     desktop-style="width: 8rem; justify-content: center"
                     mobile-style="width: 8rem; justify-content: center"
                 ></c-button>
+            </section>
+            <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
+                <span class="text-hide">Lukk</span>
+            </button>
+        </div>
+    </div>
+    <div
+        class="ReactModal__Overlay ReactModal__Overlay--after-open modal__overlay serviceAppointmentDetails hidden"
+        style="z-index: 9999; background-color: rgba(50, 65, 79, 0.8)"
+        tabindex="-1"
+        aria-label="Informasjon om oppdrag"
+    >
+        <div
+            class="ReactModal__Content ReactModal__Content--after-open navno-dekorator comments-dialog-container"
+            role="dialog"
+            aria-labelledby="comment-header-id"
+        >
+            <section>
+                <div>
+                    <h2 class="typo-undertittel">Informasjon om oppdraget:</h2>
+                </div>
+                <div if:true={isDetails}>
+                    <div class="record-details-container">
+                        <p>Oppdragsnummer: <span>{serviceAppointment.HOT_ServiceAppointmentNumber__c}</span></p>
+                        <p>Tid: <span>{serviceAppointment.StartAndEndDate}</span></p>
+                        <p>Tema: <span>{serviceAppointment.HOT_FreelanceSubject__c}</span></p>
+                        <p>Adresse: <span>{serviceAppointment.HOT_AddressFormated__c}</span></p>
+                        <p>Tolkemetode: <span>{serviceAppointment.HOT_WorkTypeName__c}</span></p>
+                        <p>Frigitt av: <span>{serviceAppointment.HOT_ReleasedBy__c}</span></p>
+                        <p>Frigitt dato: <span>{serviceAppointment.ReleaseDate}</span></p>
+                        <p>Antall påmeldte: <span>{serviceAppointment.HOT_NumberOfInterestedResources__c}</span></p>
+                        <p>Region: <span>{serviceAppointment.HOT_ServiceTerritoryName__c}</span></p>
+                        <p>Oppdragstype: <span>{serviceAppointment.HOT_AssignmentType__c}</span></p>
+                        <p>Frist dato: <span>{serviceAppointment.HOT_DeadlineDate__c}</span></p>
+                        <br />
+                    </div>
+                    <div if:true={isSeries}>
+                        <c-button
+                            button-styling="primary"
+                            button-label="Meld interesse til alle oppdrag i serien"
+                            aria-label="Meld interesse til alle oppdrag i serien"
+                            onbuttonclick={sendInterestSeries}
+                            desktop-style="width: 20rem; justify-content: center; margin-bottom: 1rem;"
+                            mobile-style="width: 100%; justify-content: center; margin-bottom: 1rem;"
+                            title="Meld interesse til alle oppdrag i serien"
+                        >
+                        </c-button>
+                        <c-table records={seriesRecords} columns={columns} onrowclick={goToRecordDetails}></c-table>
+                    </div>
+                </div>
             </section>
             <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
                 <span class="text-hide">Lukk</span>

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -30,7 +30,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
         this.dispatchEvent(eventToSend);
     }
     sendCheckedRows() {
-        this.showSendInterest = this.checkedServiceAppointments.length > 0 && !this.isDetails;
+        this.showSendInterest = this.checkedServiceAppointments.length > 0;
         this.sendInterestButtonLabel = 'Meld interesse til ' + this.checkedServiceAppointments.length + ' oppdrag';
         const eventToSend = new CustomEvent('sendcheckedrows', { detail: this.checkedServiceAppointments });
         this.dispatchEvent(eventToSend);
@@ -125,7 +125,6 @@ export default class Hot_openServiceAppointments extends LightningElement {
 
     refresh() {
         this.filters = defaultFilters();
-        this.goToRecordDetails({ detail: { Id: this.recordId } });
         this.sendRecords();
         this.sendFilters();
         this.sendCheckedRows();
@@ -144,7 +143,6 @@ export default class Hot_openServiceAppointments extends LightningElement {
     seriesRecords = [];
     showTable = true;
     goToRecordDetails(result) {
-        window.scrollTo(0, 0);
         this.serviceAppointment = undefined;
         this.seriesRecords = [];
         let recordId = result.detail.Id;
@@ -162,8 +160,11 @@ export default class Hot_openServiceAppointments extends LightningElement {
             }
         }
         this.isSeries = this.seriesRecords.length <= 1 ? false : true;
-        this.updateURL();
-        this.sendDetail();
+        this.showServiceAppointmentDetails();
+    }
+    showServiceAppointmentDetails() {
+        this.template.querySelector('.serviceAppointmentDetails').classList.remove('hidden');
+        this.template.querySelector('.serviceAppointmentDetails').focus();
     }
 
     @api recordId;
@@ -221,6 +222,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
                 let currentFilters = this.filters;
                 if (this.sendInterestAll) {
                     this.sendInterestAllComplete = true;
+                    this.checkedServiceAppointments = [];
                     return; // If series -> refresh after closeModal() to avoid showing weird data behind popup
                 }
                 refreshApex(this.wiredAllServiceAppointmentsResult).then(() => {
@@ -273,6 +275,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
     sendInterestAllComplete = false;
     sendInterestAll = false;
     sendInterestSeries() {
+        this.template.querySelector('.serviceAppointmentDetails').classList.add('hidden');
         this.hideSubmitIndicators();
         this.showCommentSection();
         this.serviceAppointmentCommentDetails = [];
@@ -304,6 +307,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
         this.sendInterestAllComplete = false;
         this.sendInterestAll = false;
         this.template.querySelector('.commentPage').classList.add('hidden');
+        this.template.querySelector('.serviceAppointmentDetails').classList.add('hidden');
     }
 
     showCommentSection() {

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.css
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.css
@@ -27,3 +27,23 @@ span {
         margin: 5vw 0;
     }
 }
+.comments-dialog-container {
+    all: unset;
+    background-color: #fff;
+    display: block;
+    padding: 5rem;
+    border-radius: 4px;
+    position: relative;
+    flex-grow: 0;
+    overflow-x: auto;
+    max-height: 100%;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    z-index: 1010;
+    max-width: 432px;
+    max-height: 75%;
+    width: 100%;
+}
+.hidden {
+    display: none;
+}

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.html
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.html
@@ -1,6 +1,6 @@
 <template>
     <div class="main-content">
-        <div if:false={isWageClaimDetails}>
+        <div>
             <div if:false={noWageClaims}>
                 <c-table records={wageClaims} columns={columns} onrowclick={goToRecordDetails}></c-table>
             </div>
@@ -9,21 +9,42 @@
                 Du har ingen ledig på lønn oppdrag.
             </div>
         </div>
-        <div if:true={isWageClaimDetails}>
-            <div class="record-details-container">
-                <p>Oppdragsnummer: <span>{wageClaim.ServiceAppointmentName__c}</span></p>
-                <p>Tid: <span>{wageClaim.StartAndEndDate}</span></p>
-                <p>Poststed: <span>{wageClaim.ServiceAppointmentCity__c}</span></p>
-                <p>Status: <span>{wageClaim.Status__c}</span></p>
-                <p>Tolkemetode: <span>{wageClaim.WorkTypeName__c}</span></p>
-            </div>
-            <c-button
-                button-styling="primary"
-                button-label="Tilbaketrekk tilgjengelighet"
-                aria-label="Tilbaketrekk tilgjengelighet"
-                onbuttonclick={retractAvailability}
+        <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open modal__overlay serviceAppointmentDetails hidden"
+            style="z-index: 9999; background-color: rgba(50, 65, 79, 0.8)"
+            tabindex="-1"
+            aria-label="Informasjon om oppdrag"
+        >
+            <div
+                class="ReactModal__Content ReactModal__Content--after-open navno-dekorator comments-dialog-container"
+                role="dialog"
+                aria-labelledby="comment-header-id"
             >
-            </c-button>
+                <section>
+                    <div>
+                        <h2 class="typo-undertittel">Informasjon om oppdraget:</h2>
+                    </div>
+                    <div if:true={isWageClaimDetails}>
+                        <div class="record-details-container">
+                            <p>Oppdragsnummer: <span>{wageClaim.ServiceAppointmentName__c}</span></p>
+                            <p>Tid: <span>{wageClaim.StartAndEndDate}</span></p>
+                            <p>Poststed: <span>{wageClaim.ServiceAppointmentCity__c}</span></p>
+                            <p>Status: <span>{wageClaim.Status__c}</span></p>
+                            <p>Tolkemetode: <span>{wageClaim.WorkTypeName__c}</span></p>
+                        </div>
+                        <c-button
+                            button-styling="primary"
+                            button-label="Tilbaketrekk tilgjengelighet"
+                            aria-label="Tilbaketrekk tilgjengelighet"
+                            onbuttonclick={retractAvailability}
+                        >
+                        </c-button>
+                    </div>
+                </section>
+                <button class="lukknapp lukknapp--overstHjorne modal__lukkknapp--shake" onclick={closeModal}>
+                    <span class="text-hide">Lukk</span>
+                </button>
+            </div>
         </div>
     </div>
 </template>

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.js
@@ -43,7 +43,6 @@ export default class Hot_wageClaimList extends LightningElement {
 
     refresh() {
         this.filters = defaultFilters();
-        this.goToRecordDetails({ detail: { Id: this.recordId } });
         this.sendRecords();
         this.sendFilters();
         this.applyFilter({ detail: { filterArray: this.filters, setRecords: true } });
@@ -74,11 +73,14 @@ export default class Hot_wageClaimList extends LightningElement {
         this.setColumns();
         refreshApex(this.wiredWageClaimsResult);
     }
-
+    closeModal() {
+        this.template.querySelector('.serviceAppointmentDetails').classList.add('hidden');
+    }
     @track wageClaim;
     isWageClaimDetails = false;
     goToRecordDetails(result) {
-        window.scrollTo(0, 0);
+        this.template.querySelector('.serviceAppointmentDetails').classList.remove('hidden');
+        this.template.querySelector('.serviceAppointmentDetails').focus();
         this.wageClaim = undefined;
         let recordId = result.detail.Id;
         this.recordId = recordId;
@@ -89,7 +91,6 @@ export default class Hot_wageClaimList extends LightningElement {
             }
         }
         this.updateURL();
-        this.sendDetail();
     }
 
     @api recordId;


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2187

Nå inkludert filene :)

Hva som er gjort:
Det er laget popup overlay til alle listene til frilanstolk. Når frilanstolk trykker inn på et oppdrag i listene skal h@n ikke miste skjermposisjonen sin. Beholder alle sine tidligere knapper.

OBS: Det går ikke an å trykke på tilbaketrekk interesse inne på påmeldte oppdrag, med mindre du ikke har endret språk på scratchorg til norsk og lagt inn oversettelse.

Testing:
Sjekk at alle lister vises som de skal når de ikke inneholder oppdrag.
Lag oppdrag til listene og trykk inn på oppdragene.
Sjekk at alle funksjoner fungerer som de skal.

FRA:
<img width="1649" alt="Skjermbilde 2023-01-31 kl  14 01 09" src="https://user-images.githubusercontent.com/111959793/216256057-53b3ecc2-b6db-4ae7-8b58-05e3cf69f7d4.png">

TIL:
<img width="1509" alt="Skjermbilde 2023-01-30 kl  12 55 38" src="https://user-images.githubusercontent.com/111959793/216255976-14ecf599-2eeb-4cb3-a081-5e7c2d41ab7c.png">
<img width="1599" alt="Skjermbilde 2023-01-30 kl  12 58 32" src="https://user-images.githubusercontent.com/111959793/216255982-586c4cf9-9a87-4172-8c2b-553d055f207f.png">
<img width="1525" alt="Skjermbilde 2023-01-31 kl  13 53 52" src="https://user-images.githubusercontent.com/111959793/216255985-cb638997-e8b7-465a-b1a2-3db4ce0dbbfd.png">
<img width="1580" alt="Skjermbilde 2023-01-31 kl  13 54 32" src="https://user-images.githubusercontent.com/111959793/216255987-866623b7-e1fe-416f-a679-ba25c959d51e.png">
<img width="1632" alt="Skjermbilde 2023-01-31 kl  14 02 20" src="https://user-images.githubusercontent.com/111959793/216255989-b0c8a8fb-2618-4272-94ea-b8f0c0a55b7c.png">
