### PR TITLE
Bestillingsskjema fix --> master

### DIFF
--- a/force-app/main/userCommunity/lwc/hot_requestForm_request/hot_requestForm_request.js
+++ b/force-app/main/userCommunity/lwc/hot_requestForm_request/hot_requestForm_request.js
@@ -33,7 +33,10 @@ export default class Hot_requestForm_request extends LightningElement {
     // }
 
     connectedCallback() {
-        document.body.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        // This gives DOM(?) time to catch up and set focus correctly
+        this.showDiv = true;
+        setTimeout(() => this.template.querySelector('h2').focus());
+
         for (let field in this.parentFieldValues) {
             if (this.fieldValues[field] != null) {
                 this.fieldValues[field] = this.parentFieldValues[field];

--- a/force-app/main/userCommunity/lwc/hot_requestForm_request/hot_requestForm_request.js
+++ b/force-app/main/userCommunity/lwc/hot_requestForm_request/hot_requestForm_request.js
@@ -27,11 +27,13 @@ export default class Hot_requestForm_request extends LightningElement {
     @api parentRequestComponentValues;
     @api isEditOrCopyMode = false;
 
-    renderedCallback() {
-        this.template.querySelector('h2').focus();
-    }
+    // Dont want to use this because focus will move to top on re-rendrering which happens on "Additional information"
+    // renderedCallback() {
+    //     this.template.querySelector('h2').focus();
+    // }
 
     connectedCallback() {
+        document.body.scrollIntoView({ behavior: 'smooth', block: 'start' });
         for (let field in this.parentFieldValues) {
             if (this.fieldValues[field] != null) {
                 this.fieldValues[field] = this.parentFieldValues[field];


### PR DESCRIPTION
I utgangspunktet en fiks på at fokus ikke blir satt på toppen når "Fyll ut mer informasjon" velges i bestillingsskjemaet pga bruk av renderedCallback(). Flyttet til connectedCallback() i stedet.

Bonus-fix: Setter fokus på h2 i bestillingsskjema i stedet for helt på topp. Man slipper da å tabbe seg gjennom hele livet.

Testes jo i community ved tabbe seg gjennom en bestilling.