### PR TITLE
Samtale på påmeldte oppdrag med riktig tid ved innsending og samtalevisning

### DIFF
--- a/force-app/main/freelanceCommunity/classes/HOT_InterestedResourcesListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_InterestedResourcesListController.cls
@@ -113,13 +113,17 @@ public without sharing class HOT_InterestedResourcesListController {
 
     @AuraEnabled
     public static void addComment(Id interestedResourceId, String newComment) {
+        Datetime now = Datetime.now();
+        String osloTimeZone = 
+  now.format('yyyy-MM-dd-HH:mm:ss', 
+                 'Europe/Oslo');
         if (newComment != null && newComment != '') {
             newComment =
                 UserInfo.getFirstName() +
                 ' ' +
                 UserInfo.getLastName() +
                 ', ' +
-                Datetime.now() +
+                osloTimeZone +
                 ': ' +
                 newComment;
             HOT_InterestedResource__c interestedResource = [

--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.js
@@ -202,6 +202,7 @@ export default class Hot_interestedResourcesList extends LightningElement {
     @track prevComments = '';
     fixComments() {
         getComments({ interestedResourceId: this.recordId }).then((result) => {
+            this.prevComments = '';
             console.log(result.Comments__c);
             if (result.Comments__c != undefined || result.Comments__c != '') {
                 this.prevComments = result.Comments__c.split('\n\n');


### PR DESCRIPTION
Fikset sånn at samtalen nullstilles hver gang når man åpner opp et annet oppdrag, og at det er riktig tidssone når bruker sender melding