### PR TITLE
Fikser problemet med varsler på arbeidsordrer og oppdrag uten bruker

### DIFF
--- a/force-app/main/notification/classes/HOT_ServiceAppointmentNotification.cls
+++ b/force-app/main/notification/classes/HOT_ServiceAppointmentNotification.cls
@@ -350,7 +350,9 @@ public without sharing class HOT_ServiceAppointmentNotification {
             for (WorkOrder wo : workordersList) {
                 isPerson = wo.Account.CRM_Person__c != null ? true : false;
                 Set<String> recipients = new Set<String>();
-                recipients.add(userIdByAccountId.get(wo.AccountId));
+                if (userIdByAccountId.get(wo.AccountId) != null) {
+                    recipients.add(userIdByAccountId.get(wo.AccountId));
+                }
                 if (recipients.size() != 0 && isPerson) {
                     if (wo.Account.CRM_Person__r.HOT_NotificationChannel__c.contains('Push')) {
                         HOT_UserNotificationService.interpreterAddedNotification(
@@ -401,7 +403,9 @@ public without sharing class HOT_ServiceAppointmentNotification {
             for (WorkOrder wo : workordersList) {
                 isPerson = wo.Account.CRM_Person__c != null ? true : false;
                 Set<String> recipients = new Set<String>();
-                recipients.add(userIdByAccountId.get(wo.AccountId));
+                if (userIdByAccountId.get(wo.AccountId) != null) {
+                    recipients.add(userIdByAccountId.get(wo.AccountId));
+                }
                 if (recipients.size() != 0 && isPerson) {
                     if (wo.Account.CRM_Person__r.HOT_NotificationChannel__c.contains('Push')) {
                         HOT_UserNotificationService.interpreterChangeNotification(

--- a/force-app/main/triggers/classes/HOT_WorkOrderHandler.cls
+++ b/force-app/main/triggers/classes/HOT_WorkOrderHandler.cls
@@ -424,7 +424,9 @@ public without sharing class HOT_WorkOrderHandler extends MyTriggers {
         if (!workordersList.isEmpty()) {
             for (WorkOrder wo : workordersList) {
                 Set<String> recipients = new Set<String>();
-                recipients.add(userIdByAccountId.get(wo.AccountId));
+                if (userIdByAccountId.get(wo.AccountId) != null) {
+                    recipients.add(userIdByAccountId.get(wo.AccountId));
+                }
                 if (recipients.size() != 0) {
                     if (wo.Account.CRM_Person__r.HOT_NotificationChannel__c.contains('Push')) {
                         HOT_UserNotificationService.newWorkOrderNotification(


### PR DESCRIPTION
Problemet er at `recipients` inneholder verdien `null` og dermed ikke er tom, så den går videre og prøver å opprette et varsel. La til en sjekk på om `userIdByAccountId.get(wo.AccountId)` faktisk returnerer en Id.