### PR TITLE
TOLK-2236: Fiks på at formidler får ikke endre status i listevisninger

### DIFF
--- a/force-app/main/notification/classes/HOT_ServiceAppointmentNotification.cls
+++ b/force-app/main/notification/classes/HOT_ServiceAppointmentNotification.cls
@@ -15,7 +15,8 @@ public without sharing class HOT_ServiceAppointmentNotification {
             if (
                 serviceAppointment.HOT_AssignedResourceId__c != null &&
                 oldServiceAppointment.Status != serviceAppointment.Status &&
-                serviceAppointment.Status == 'Dispatched'
+                serviceAppointment.Status == 'Dispatched' &&
+                serviceAppointment.AccountId != null
             ) {
                 Set<String> interpreterRecipients = new Set<String>{ serviceAppointment.HOT_AssignedResourceId__c };
                 resourceAdded(notificationType, serviceAppointment, interpreterRecipients);
@@ -28,7 +29,8 @@ public without sharing class HOT_ServiceAppointmentNotification {
                 serviceAppointment.HOT_AssignedResourceId__c != null &&
                 oldServiceAppointment.HOT_AssignedResourceId__c != null &&
                 serviceAppointment.HOT_AssignedResourceId__c != oldServiceAppointment.HOT_AssignedResourceId__c &&
-                serviceAppointment.Status == 'Dispatched'
+                serviceAppointment.Status == 'Dispatched' &&
+                serviceAppointment.AccountId != null
             ) {
                 Set<String> interpreterRecipients = new Set<String>{ serviceAppointment.HOT_AssignedResourceId__c };
                 resourceAdded(notificationType, serviceAppointment, interpreterRecipients);


### PR DESCRIPTION
Ser ut som det har sammenheng med oppdrag som ikke er knyttet til bruker.

Følgene spørring som feiler: `List<User> users = [SELECT Id, AccountId FROM User WHERE AccountId IN :accountIds];`

```
11:00:03.527 (5529194588)|FATAL_ERROR|System.LimitException: Too many query rows: 50001

Class.HOT_ServiceAppointmentNotification.notifyUserOnAddedResource: line 323, column 1
Class.HOT_ServiceAppointmentNotification.resourceServiceAppointmentChanged: line 23, column 1
Class.HOT_ServiceAppointmentHandler.onAfterUpdate: line 405, column 1
Class.MyTriggers.run: line 620, column 1
Class.MyTriggers.run: line 567, column 1
Class.MyTriggers.run: line 143, column 1
Trigger.ServiceAppointmentTrigger: line 11, column 1
```

Har lagt inn et filter som fjerner de oppdragene som ikke er knytte til bruker.

Det ser ut som koden ikke er bulkifisert, så logikken i `notifyUserOnAddedResource()` og `notifyUserOnChangedResource`  kjører for hvert oppdrag man endrer og det vil si at spørringene kjører for hvert oppdrag.

Det er 18 tusen brukere hvor `AccountId = null`, så det funker å endre 1 eller 2, men når man prøver å endre 3 blir totalen over 50k.