### PR TITLE
Endret utdaterte kall i newScratchOrg-scriptene

### DIFF
--- a/scripts/bat/newScratchOrg.bat
+++ b/scripts/bat/newScratchOrg.bat
@@ -2,28 +2,28 @@ echo "Oppretter scratch org"
 call sfdx force:org:create -f config\project-scratch-def.json --setalias %1 --durationdays %2 --setdefaultusername --json --loglevel fatal  --wait 10
 
 echo "Installerer crm-platform-base ver. 0.186"
-call sfdx force:package:install --package 04t7U0000008r7rQAA -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008r7rQAA -r -k %3 --wait 10 --publish-wait 10
 
 echo "Installerer crm-platform-integration ver. 0.98"
-call sfdx force:package:install --package 04t7U0000008rFCQAY -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008rFCQAY -r -k %3 --wait 10 --publish-wait 10
 
 echo "Installerer crm-platform-access-control ver. 0.107"
-call sfdx force:package:install --package 04t7U0000008r15QAA -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008r15QAA -r -k %3 --wait 10 --publish-wait 10
 
 echo "Installerer crm-community-base ver. 0.85"
-call sfdx force:package:install --package 04t7U0000008rHNQAY -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008rHNQAY -r -k %3 --wait 10 --publish-wait 10
 
 echo "Installerer crm-platform-reporting ver. 0.30"
-call sfdx force:package:install --package 04t7U0000008qnNQAQ -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008qnNQAQ -r -k %3 --wait 10 --publish-wait 10
 
 echo "Installer crm-henvendelse-base ver. 0.14"
-call sfdx force:package:install --package 04t7U0000008r4dQAA -r -k %3 --wait 10 --publishwait 10
+call sfdx package:install --package 04t7U0000008r4dQAA -r -k %3 --wait 10 --publish-wait 10
 
 echo "Dytter kildekoden til scratch org'en"
 call sfdx force:source:push
 
 echo "Tildeler tilatelsessett til brukeren"
-call sfdx force:user:permset:assign --permsetname "HOT_admin, HOT_Config"
+call sfdx force:user:permset:assign --perm-set-name "HOT_admin, HOT_Config"
 
 echo "Publish Experience Site"
 call sfdx force:community:publish --name Tolketjenesten

--- a/scripts/bat/newScratchOrg.bat
+++ b/scripts/bat/newScratchOrg.bat
@@ -26,9 +26,9 @@ echo "Tildeler tilatelsessett til brukeren"
 call sfdx force:user:permset:assign --perm-set-name "HOT_admin, HOT_Config"
 
 echo "Publish Experience Site"
-call sfdx force:community:publish --name Tolketjenesten
+call sfdx community:publish --name Tolketjenesten
 
 echo "Oppretter testdata"
-call sfdx force:apex:execute -f scripts/apex/createTestData.apex
+call sfdx apex run -f scripts/apex/createTestData.apex
 
 echo "Ferdig"

--- a/scripts/bat/newScratchOrgMac
+++ b/scripts/bat/newScratchOrgMac
@@ -28,9 +28,9 @@ sfdx force:source:push
 sfdx force:user:permset:assign --perm-set-name "HOT_admin, HOT_Config"
 
 # Publish Experience Site
-sfdx force:community:publish --name Tolketjenesten
+sfdx community:publish --name Tolketjenesten
 
 # Opprett testdata
-sfdx force:apex:execute -f scripts/apex/createTestData.apex
+sfdx apex run -f scripts/apex/createTestData.apex
 
 # done

--- a/scripts/bat/newScratchOrgMac
+++ b/scripts/bat/newScratchOrgMac
@@ -4,28 +4,28 @@
 sfdx force:org:create -f config/project-scratch-def.json --setalias $1 --durationdays $2 --setdefaultusername --json --loglevel fatal  --wait 10
 
 # Installer crm-platform-base ver. 0.186
-sfdx force:package:install --package 04t7U0000008r7rQAA -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008r7rQAA -r -k $3 --wait 10 --publish-wait 10
 
 # Installer crm-platform-integration ver. 0.98
-sfdx force:package:install --package 04t7U0000008rFCQAY -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008rFCQAY -r -k $3 --wait 10 --publish-wait 10
 
 # Installer crm-platform-access-control ver. 0.107
-sfdx force:package:install --package 04t7U0000008r15QAA -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008r15QAA -r -k $3 --wait 10 --publish-wait 10
 
 # Installer crm-community-base ver. 0.85
-sfdx force:package:install --package 04t7U0000008rHNQAY -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008rHNQAY -r -k $3 --wait 10 --publish-wait 10
 
 # Installer crm-platform-reporting ver. 0.30
-sfdx force:package:install --package 04t7U0000008qnNQAQ -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008qnNQAQ -r -k $3 --wait 10 --publish-wait 10
 
 # Installer crm-henvendelse-base ver. 0.14
-sfdx force:package:install --package 04t7U0000008r4dQAA -r -k $3 --wait 10 --publishwait 10
+sfdx package:install --package 04t7U0000008r4dQAA -r -k $3 --wait 10 --publish-wait 10
 
 # Dytt kildekoden til scratch org'en
 sfdx force:source:push
 
 # Tildel tilatelsessett til brukeren
-sfdx force:user:permset:assign --permsetname "HOT_admin, HOT_Config"
+sfdx force:user:permset:assign --perm-set-name "HOT_admin, HOT_Config"
 
 # Publish Experience Site
 sfdx force:community:publish --name Tolketjenesten


### PR DESCRIPTION
Vi har hatt noen deprecation-warnings i newScratchOrg-scriptene våre. Disse er nå endret til sine oppdaterte kall.

force:package:install har blitt endret til package:install
--publishwait har blitt endret til --publish-wait
--permsetname har blitt endret til --perm-set-name
force:community:publish har blitt endret til community:publish
force:apex:execute har blitt endret til apex run