### PR TITLE
Tolk 2237 - full bredde på avlys popup på mobil + frilanstolk lister på mobil

### DIFF
--- a/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_interestedResourcesList/hot_interestedResourcesList.css
@@ -22,11 +22,6 @@ span {
     font-weight: normal;
 }
 
-@media (max-width: 576px) {
-    .record-details-container {
-        margin: 5vw 0;
-    }
-}
 .comments-dialog-container {
     all: unset;
     background-color: #fff;
@@ -44,6 +39,32 @@ span {
     max-height: 75%;
     width: 100%;
 }
+@media (max-width: 576px) {
+    .record-details-container {
+        margin: 5vw 0;
+    }
+    .comments-dialog-container {
+        all: unset;
+        background-color: #fff;
+        display: block;
+        padding: 3rem;
+        border-radius: 4px;
+        position: relative;
+        flex-grow: 0;
+        overflow-x: auto;
+        max-height: 100%;
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+        z-index: 1010;
+        max-width: 432px;
+        max-height: 75%;
+        width: 100%;
+    }
+}
 .hidden {
     display: none;
+}
+lightning-button {
+    display: flex;
+    justify-content: center;
 }

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.css
@@ -24,12 +24,6 @@ span {
 .files-container {
     margin-top: 1rem;
 }
-
-@media (max-width: 576px) {
-    .record-details-container {
-        margin: 5vw 0;
-    }
-}
 .flow-container {
     margin: 2rem 0;
     max-width: 500px;
@@ -50,6 +44,28 @@ span {
     max-width: 432px;
     max-height: 75%;
     width: 100%;
+}
+@media (max-width: 576px) {
+    .record-details-container {
+        margin: 5vw 0;
+    }
+    .comments-dialog-container {
+        all: unset;
+        background-color: #fff;
+        display: block;
+        padding: 3rem;
+        border-radius: 4px;
+        position: relative;
+        flex-grow: 0;
+        overflow-x: auto;
+        max-height: 100%;
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+        z-index: 1010;
+        max-width: 432px;
+        max-height: 75%;
+        width: 100%;
+    }
 }
 .hidden {
     display: none;

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.css
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.css
@@ -55,12 +55,6 @@ span {
     font-weight: normal;
 }
 
-@media (max-width: 576px) {
-    .record-details-container {
-        margin: 5vw 0;
-    }
-}
-
 lightning-input-field.ikke-sensitive-opplysninger > lightning-textarea > label:after {
     content: ' (ingen sensitive opplysninger)';
 }
@@ -89,6 +83,28 @@ lightning-input-field.ikke-sensitive-opplysninger > lightning-textarea > label:a
     max-width: 432px;
     max-height: 75%;
     width: 100%;
+}
+@media (max-width: 576px) {
+    .record-details-container {
+        margin: 5vw 0;
+    }
+    .comments-dialog-container {
+        all: unset;
+        background-color: #fff;
+        display: block;
+        padding: 3rem;
+        border-radius: 4px;
+        position: relative;
+        flex-grow: 0;
+        overflow-x: auto;
+        max-height: 100%;
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+        z-index: 1010;
+        max-width: 432px;
+        max-height: 75%;
+        width: 100%;
+    }
 }
 
 .meld-interesse-overlay {

--- a/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.html
+++ b/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.html
@@ -200,7 +200,7 @@
         header={modalHeader}
         content={modalContent}
         desktop-style="text-align: center; white-space: pre-line; width: 50%"
-        mobile-style="text-align: center; white-space: pre-line; width: 100%"
+        mobile-style="text-align: center; white-space: pre-line; width: 100%; max-width: 100%;"
         center-buttons="true"
         no-cancel-button={noCancelButton}
         onbuttonclick={handleAlertDialogClick}

--- a/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.css
+++ b/force-app/main/wageClaim/lwc/hot_wageClaimList/hot_wageClaimList.css
@@ -21,12 +21,6 @@ p {
 span {
     font-weight: normal;
 }
-
-@media (max-width: 576px) {
-    .record-details-container {
-        margin: 5vw 0;
-    }
-}
 .comments-dialog-container {
     all: unset;
     background-color: #fff;
@@ -43,6 +37,28 @@ span {
     max-width: 432px;
     max-height: 75%;
     width: 100%;
+}
+@media (max-width: 576px) {
+    .record-details-container {
+        margin: 5vw 0;
+    }
+    .comments-dialog-container {
+        all: unset;
+        background-color: #fff;
+        display: block;
+        padding: 3rem;
+        border-radius: 4px;
+        position: relative;
+        flex-grow: 0;
+        overflow-x: auto;
+        max-height: 100%;
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+        z-index: 1010;
+        max-width: 432px;
+        max-height: 75%;
+        width: 100%;
+    }
 }
 .hidden {
     display: none;


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2237

Fikset slik at ikke informasjon om oppdraget blir splittet til ny linje pga det var padding på rundt 10 meter på hver side av info tekstene. 

Og det er full bredde på popup når tolkebruker eller bestiller skal avlyse oppdrag.

Skal ikke påvirke desktop.