### PR TITLE
TOLK-2242: Update HOT_ServiceResourceHandler.cls --> master Missing MiddleName

### DIFF
--- a/force-app/main/triggers/classes/HOT_ServiceResourceHandler.cls
+++ b/force-app/main/triggers/classes/HOT_ServiceResourceHandler.cls
@@ -22,7 +22,7 @@ public without sharing class HOT_ServiceResourceHandler {
     //Kjøres fra User trigger onInsert
     @Future
     public static void createServiceResourceFuture(List<Id> userIds) {
-        List<User> users = [SELECT Id, Name, ProfileId, Department FROM User WHERE Id IN :userIds];
+        List<User> users = [SELECT Id, Name, MiddleName, ProfileId, Department FROM User WHERE Id IN :userIds];
         createServiceResource(users, true, 'AUTO');
     }
 


### PR DESCRIPTION
________________________________________
Fra: ApexApplication <[info@emea.salesforce.com](mailto:info@emea.salesforce.com)>
Sendt: torsdag 13. april 2023 14:46:54 (UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna
Til: Fosli, Carl Huseby
Emne: Developer script exception from NAV : 'HOT_ServiceResourceHandler' for job id '7077U000022EPZd' : **SObject row was retrieved via SOQL without querying the requested field: User.MiddleName**

Apex script unhandled exception by user/organization: 0052o000009WHXx/00D2o000000aANV

Failed to invoke future method 'public static void createServiceResourceFuture(List<Id>)' on class 'HOT_ServiceResourceHandler' for job id '7077U000022EPZd'

caused by: System.SObjectException: SObject row was retrieved via SOQL without querying the requested field: User.MiddleName

Class.HOT_ServiceResourceHandler.createServiceResource: line 47, column 1
Class.HOT_ServiceResourceHandler.createServiceResourceFuture: line 26, column 1