### PR TITLE
Husker checkboxvalg

### DIFF
--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -79,14 +79,15 @@ export default class Hot_openServiceAppointments extends LightningElement {
     renderedCallback() {
         this.setPreviousFiltersOnRefresh();
         this.setCheckedRowsOnRefresh();
+        sessionStorage.setItem('checkedrowsSavedForRefresh', JSON.stringify(this.checkedServiceAppointments));
     }
 
     @track filters = [];
     connectedCallback() {
-        // if (localStorage.getItem('checkedrowsSavedForRefresh')) {
-        //     this.checkedServiceAppointments = JSON.parse(localStorage.getItem('checkedrowsSavedForRefresh'));
-        //     localStorage.removeItem('checkedrowsSavedForRefresh');
-        // }
+        if (sessionStorage.getItem('checkedrowsSavedForRefresh')) {
+            this.checkedServiceAppointments = JSON.parse(sessionStorage.getItem('checkedrowsSavedForRefresh'));
+            sessionStorage.removeItem('checkedrowsSavedForRefresh');
+        }
         this.setColumns();
         refreshApex(this.wiredAllServiceAppointmentsResult);
         this.breadcrumbs = [


### PR DESCRIPTION
Sjekk at den husker checkboxvalgene ved skifte av liste og ved refresh på LEDIGE OPPDRAG

Når man går helt ut til startsiden og inn på listene igjen skal den IKKE huske.