### PR TITLE
Endret ordlyder som inneholder sms til å være mer passende ettersom vi i har støtte for flere varslingskanaler.

### DIFF
--- a/force-app/main/default/objectTranslations/HOT_Request__c-no/IsOrdererWantStatusUpdateOnSMS__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/HOT_Request__c-no/IsOrdererWantStatusUpdateOnSMS__c.fieldTranslation-meta.xml
@@ -3,6 +3,6 @@
     <help>
         <!-- Når denne er huket av, vil bestiller på vegne av bruker få sms når status på bestilling endres. -->
     </help>
-    <label>SMS til bestiller ved statusendringer?</label>
+    <label>Varsel til bestiller ved statusendringer?</label>
     <name>IsOrdererWantStatusUpdateOnSMS__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/HOT_Request__c-no/IsReminderSMS__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/HOT_Request__c-no/IsReminderSMS__c.fieldTranslation-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <label>Sende påminnelse på SMS?</label>
+    <label>Sende påminnelse?</label>
     <name>IsReminderSMS__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objects/HOT_Request__c/fields/IsOrdererWantStatusUpdateOnSMS__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Request__c/fields/IsOrdererWantStatusUpdateOnSMS__c.field-meta.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsOrdererWantStatusUpdateOnSMS__c</fullName>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
-    <inlineHelpText>Når denne er huket av, vil bestiller på vegne av bruker få sms når status på bestilling endres.</inlineHelpText>
+    <inlineHelpText
+    >Når denne er huket av, vil bestiller på vegne av bruker få varsel når status på bestillingen endres.</inlineHelpText>
     <label>Orderer Status SMS?</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/HOT_Request__c/fields/IsOrdererWantStatusUpdateOnSMS__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Request__c/fields/IsOrdererWantStatusUpdateOnSMS__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText
     >Når denne er huket av, vil bestiller på vegne av bruker få varsel når status på bestillingen endres.</inlineHelpText>
-    <label>Orderer Status SMS?</label>
+    <label>Orderer Status Notification?</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>

--- a/force-app/main/default/objects/HOT_Request__c/fields/IsReminderSMS__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Request__c/fields/IsReminderSMS__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText
     >Når denne er huket av, vil bruker få påminnelse dagen før det finner sted. Om bruker har reservert seg for varsler, vil de ikke motta denne påminnelsen.</inlineHelpText>
-    <label>Reminder SMS?</label>
+    <label>Reminder notification?</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>

--- a/force-app/main/default/objects/HOT_Request__c/fields/IsReminderSMS__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Request__c/fields/IsReminderSMS__c.field-meta.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsReminderSMS__c</fullName>
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
-    <inlineHelpText>Når denne er huket av, vil bruker få påminnelse om tolkeoppdraget dagen før det finner sted. Om bruker har reservasjon mot sms-påminnelse, se person detaljer, vil de ikke motta denne påminnelsen.</inlineHelpText>
+    <inlineHelpText
+    >Når denne er huket av, vil bruker få påminnelse dagen før det finner sted. Om bruker har reservert seg for varsler, vil de ikke motta denne påminnelsen.</inlineHelpText>
     <label>Reminder SMS?</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,7 +8,7 @@
             "default": true,
             "package": "crm-hot",
             "versionName": "ver 0.1",
-            "versionNumber": "1.216.0.NEXT",
+            "versionNumber": "1.217.0.NEXT",
             "dependencies": [
                 {
                     "package": "crm-platform-base",


### PR DESCRIPTION
Test: 
Gå inn på en request og sjekk feltene: "Order Status SMS?" og "Reminder SMS?" har riktige ordlyder,

* "Order Status SMS?" sin ordlyd skal være: 
"Når denne er huket av, vil bestiller på vegne av bruker få varsel når status på bestillingen endres."

* "Reminder SMS?" skal være: 
"Når denne er huket av, vil bruker få påminnelse dagen før det finner sted. Om bruker har reservert seg for varsler, vil de ikke motta denne påminnelsen."