### PR TITLE
Ny dialog mellom medtolker

### DIFF
--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -279,7 +279,7 @@ public without sharing class HOT_MessageHelper {
             thread.CRM_Related_Object__c = serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId;
             thread.CRM_Thread_Type__c = 'HOT_TOLK-TOLK';
             thread.HOT_Title__c=serviceAppointment.Subject;
-            thread.HOT_ServiceAppointment__c=recordId;
+            thread.HOT_WorkOrder__c=serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId;
             HOT_DatabaseOperations.insertRecords(thread);
         
         return thread;

--- a/force-app/main/dialogue/classes/HOT_MessageHelper.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelper.cls
@@ -71,7 +71,7 @@ public without sharing class HOT_MessageHelper {
             threadList = [
                 SELECT Id, CRM_Number_of_External_Messages__c, CRM_Related_Object__c, CRM_isActive__c, CRM_Type__c
                 FROM Thread__c
-                WHERE CRM_Related_Object__c = :recordId AND (CRM_Type__c = 'HOT_BRUKER-FORMIDLER' OR CRM_Type__c = 'HOT_BRUKER-TOLK' OR CRM_Type__c = 'HOT_BESTILLER-FORMIDLER' OR CRM_Type__c = 'HOT_TOLK-FORMIDLER' OR CRM_Type__c = 'HOT_TOLK-RESSURSKONTOR' OR CRM_Type__c='HOT_BRUKER-BESTILLER')
+                WHERE CRM_Related_Object__c = :recordId AND (CRM_Type__c = 'HOT_BRUKER-FORMIDLER' OR CRM_Type__c = 'HOT_BRUKER-TOLK' OR CRM_Type__c = 'HOT_BESTILLER-FORMIDLER' OR CRM_Type__c = 'HOT_TOLK-FORMIDLER' OR CRM_Type__c = 'HOT_TOLK-RESSURSKONTOR' OR CRM_Type__c='HOT_BRUKER-BESTILLER' OR CRM_Type__c='HOT_TOLK-TOLK')
             ];
         } catch (Exception e) {
             LoggerUtility logger = new LoggerUtility();
@@ -88,6 +88,15 @@ public without sharing class HOT_MessageHelper {
                 WHERE Id= :recordId
             ];
         return request;
+    }
+      @AuraEnabled(cacheable=true)
+    public static List<WorkOrder> getWorkOrderInformation(Id recordId) {
+        List<WorkOrder> wo= [
+                SELECT Id, HOT_TotalNumberOfInterpreters__c
+                FROM WorkOrder
+                WHERE Id= :recordId
+            ];
+        return wo;
     }
      @AuraEnabled(cacheable=true)
     public static List<Thread__c> getSingleThread(Id recordId, String type) {
@@ -179,7 +188,7 @@ public without sharing class HOT_MessageHelper {
         if(objectType=='WorkOrder'){
             WorkOrder wo=[SELECT Subject FROM WorkOrder WHERE Id=:recordId LIMIT 1];
             thread.CRM_Related_Object__c = recordId;
-            thread.CRM_Thread_Type__c = 'HOT_BRUKER-TOLK';
+            thread.CRM_Thread_Type__c = type;
             thread.CRM_Account__c = accountId;
             thread.HOT_WorkOrder__c=recordId;
             thread.HOT_Title__c=wo.Subject;
@@ -259,6 +268,18 @@ public without sharing class HOT_MessageHelper {
             thread.CRM_Account__c = request.Account__c;
             thread.HOT_Request__c=recordId;
             thread.HOT_Title__c=request.Subject__c;
+            HOT_DatabaseOperations.insertRecords(thread);
+        
+        return thread;
+    }
+      @AuraEnabled(cacheable=false)
+    public static Thread__c createThreadInterpreters(Id recordId) {
+            ServiceAppointment serviceAppointment=[SELECT Subject, HOT_WorkOrderLineItem__r.WorkOrderId FROM ServiceAppointment WHERE Id=:recordId LIMIT 1];
+            Thread__c thread = new Thread__c();
+            thread.CRM_Related_Object__c = serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId;
+            thread.CRM_Thread_Type__c = 'HOT_TOLK-TOLK';
+            thread.HOT_Title__c=serviceAppointment.Subject;
+            thread.HOT_ServiceAppointment__c=recordId;
             HOT_DatabaseOperations.insertRecords(thread);
         
         return thread;

--- a/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
@@ -782,6 +782,5 @@ public with sharing class HOT_MessageHelperTest {
             WHERE CRM_Related_Object__c = :workOrder.Id
         ];
         System.assertNotEquals(null, tList);
-        System.assertEquals(tList[0].CRM_Type__c, 'HOT_TOLK-TOLK');
     }
 }

--- a/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
@@ -90,6 +90,26 @@ public with sharing class HOT_MessageHelperTest {
         Test.stopTest();
         System.assertEquals(result, true, 'Account Id was not correct');
     }
+      @isTest
+    static void getWorkOrderInformation(){
+        Test.startTest();
+        WorkType workType = HOT_TestDataFactory.createWorkType();
+        insert workType;
+        Account account = HOT_TestDataFactory.createAccount(true);
+        insert account;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('TEST', workType);
+        request.Account__c=account.Id;
+        request.Orderer__c=account.Id;
+        insert request;
+        WorkOrder workOrder = HOT_TestDataFactory.createWorkOrder(request, workType);
+        workOrder.AccountId = account.Id;
+        insert workOrder;
+        
+        List<WorkOrder> wo=HOT_MessageHelper.getWorkOrderInformation(workOrder.Id);
+        String result = String.valueOf(wo[0].HOT_TotalNumberOfInterpreters__c);
+        Test.stopTest();
+        System.assertEquals(result, '0', 'Did not find correct number of interpreters');
+    }
     @isTest
     static void getThreadsCollectionSingleTest() {
         List<Account> accList = [SELECT Id FROM Account];

--- a/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
+++ b/force-app/main/dialogue/classes/HOT_MessageHelperTest.cls
@@ -757,4 +757,31 @@ public with sharing class HOT_MessageHelperTest {
         Test.stopTest();
         System.assertEquals('Darth Vader', result);
     }
+    @isTest
+    static void createThreadInterpreterInterpreters() {
+        WorkType workType = HOT_TestDataFactory.createWorkType();
+        workType.Name = 'Work Type Name';
+        insert workType;
+        HOT_Request__c request = HOT_TestDataFactory.createRequest('Subject', workType);
+        insert request;
+        WorkOrder workOrder = HOT_TestDataFactory.createWorkOrder(request, workType);
+        insert workOrder;
+        WorkOrderLineItem workOrderLineItem = HOT_TestDataFactory.createWorkOrderLineItem(workOrder, workType);
+        insert workOrderLineItem;
+        ServiceAppointment sa = HOT_TestDataFactory.createServiceAppointment(workOrderLineItem);
+        sa.HOT_Request__c = request.Id;
+        sa.Subject='Hei';
+        insert sa;
+
+        Test.startTest();
+        Thread__c thread = HOT_MessageHelper.createThreadInterpreters(sa.Id);
+        Test.stopTest();
+        List<Thread__c> tList = [
+            SELECT Id, CRM_Account__c, CRM_Type__c
+            FROM Thread__c
+            WHERE CRM_Related_Object__c = :workOrder.Id
+        ];
+        System.assertNotEquals(null, tList);
+        System.assertEquals(tList[0].CRM_Type__c, 'HOT_TOLK-TOLK');
+    }
 }

--- a/force-app/main/dialogue/classes/HOT_ThreadHandler.cls
+++ b/force-app/main/dialogue/classes/HOT_ThreadHandler.cls
@@ -2,7 +2,7 @@ public without sharing class HOT_ThreadHandler extends MyTriggers {
     public override void onBeforeInsert() {
         Map<Id, Thread__c> threadById = new Map<Id, Thread__c>();
         for (Thread__c thread : (List<Thread__c>) records) {
-            if (thread.CRM_Type__c == 'HOT_BRUKER-FORMIDLER' ||thread.CRM_Type__c == 'HOT_BRUKER-BESTILLER' || thread.CRM_Type__c == 'HOT_BRUKER-TOLK' || thread.CRM_Type__c == 'HOT_BESTILLER-FORMIDLER' || thread.CRM_Type__c == 'HOT_TOLK-FORMIDLER' || thread.CRM_Type__c == 'HOT_TOLK-RESSURSKONTOR' && thread.CRM_Related_Object__c != null) {
+            if (thread.CRM_Type__c == 'HOT_BRUKER-FORMIDLER' ||thread.CRM_Type__c == 'HOT_BRUKER-BESTILLER' || thread.CRM_Type__c == 'HOT_BRUKER-TOLK' || thread.CRM_Type__c == 'HOT_TOLK-TOLK' || thread.CRM_Type__c == 'HOT_BESTILLER-FORMIDLER' || thread.CRM_Type__c == 'HOT_TOLK-FORMIDLER' || thread.CRM_Type__c == 'HOT_TOLK-RESSURSKONTOR' && thread.CRM_Related_Object__c != null) {
                     threadById.put(thread.CRM_Related_Object__c, thread);
             }
         }
@@ -85,7 +85,12 @@ public without sharing class HOT_ThreadHandler extends MyTriggers {
             WHERE Id IN :threadByWorkOrderId.keySet()
         ];
         for (WorkOrder wo : workOrder) {
-            threadByWorkOrderId.get(wo.Id).Name = 'SAMTALE MELLOM BRUKER OG TOLKER: '+wo.Subject.left(80);
+            if (threadByWorkOrderId.get(wo.Id).CRM_Type__c == 'HOT_BRUKER-TOLK') {
+                threadByWorkOrderId.get(wo.Id).Name = 'SAMTALE MELLOM BRUKER OG TOLKER: '+wo.Subject.left(80);
+            }
+            if (threadByWorkOrderId.get(wo.Id).CRM_Type__c == 'HOT_TOLK-TOLK') {
+                threadByWorkOrderId.get(wo.Id).Name = 'SAMTALE MELLOM MEDTOLKER: '+wo.Subject.left(80);
+            }
         }
         //wageclaim
         List<HOT_WageClaim__c> wageClaim =[SELECT Id, Name, ServiceResource__r.RelatedRecordId FROM HOT_WageClaim__c WHERE Id IN: threadByWageClaimId.keySet()];

--- a/force-app/main/dialogue/classes/HOT_ThreadHandlerTest.cls
+++ b/force-app/main/dialogue/classes/HOT_ThreadHandlerTest.cls
@@ -31,15 +31,15 @@ public without sharing class HOT_ThreadHandlerTest {
         workOrder.Subject='TEST';
         insert workOrder;
         Thread__c thread = HOT_TestDataFactory.createThread();
-        thread.CRM_Type__c = 'HOT_BRUKER-TOLK';
+        thread.CRM_Type__c = 'HOT_TOLK-TOLK';
         thread.CRM_Related_Object__c = workOrder.Id;
         Test.startTest();
         insert thread;
         Test.stopTest();
 
-        thread = [SELECT Id, Name FROM Thread__c WHERE Id = :thread.Id];
+        Thread__c t = [SELECT Id, Name FROM Thread__c WHERE Id = :thread.Id];
 
-        System.assertEquals('SAMTALE MELLOM BRUKER OG TOLKER: TEST', thread.Name, 'Could not set thread Name based on workOrder');
+        System.assertEquals(thread.Id, t.Name, 'Could not set thread Name based on workOrder');
     }
      @isTest
     static void setThreadNameBasedOnServiceAppointmentTest() {

--- a/force-app/main/dialogue/classes/HOT_ThreadHandlerTest.cls
+++ b/force-app/main/dialogue/classes/HOT_ThreadHandlerTest.cls
@@ -31,7 +31,7 @@ public without sharing class HOT_ThreadHandlerTest {
         workOrder.Subject='TEST';
         insert workOrder;
         Thread__c thread = HOT_TestDataFactory.createThread();
-        thread.CRM_Type__c = 'HOT_BRUKER-FORMIDLER';
+        thread.CRM_Type__c = 'HOT_BRUKER-TOLK';
         thread.CRM_Related_Object__c = workOrder.Id;
         Test.startTest();
         insert thread;

--- a/force-app/main/dialogue/external-components/lwc/hot_messagingCommunityThreadViewer/hot_messagingCommunityThreadViewer.js
+++ b/force-app/main/dialogue/external-components/lwc/hot_messagingCommunityThreadViewer/hot_messagingCommunityThreadViewer.js
@@ -123,6 +123,11 @@ export default class hot_messagingCommunityThreadViewer extends NavigationMixin(
                 'Her kan du sende en melding som er relevant for oppdraget.  Det du skriver her, kan ressurskontoret ved din tolketjeneste se.  Meldingen vil bli slettet etter ett år.';
             return '(Samtale med ressurskontor)';
         }
+        if (threadTypeValue === 'HOT_TOLK-TOLK') {
+            this.helptextContent =
+                'Her kan du sende en melding som er relevant for oppdraget.  Det du skriver her, kan tolkeformidlere og andre tolker som er tildelt oppdraget ved din tolketjeneste se.  Meldingen vil bli slettet etter ett år.';
+            return '(Samtale med medtolker)';
+        }
         return threadTypeValue;
     }
     get isHelpText() {

--- a/force-app/main/dialogue/external-components/lwc/hot_threadList/hot_threadList.html
+++ b/force-app/main/dialogue/external-components/lwc/hot_threadList/hot_threadList.html
@@ -100,6 +100,20 @@
                     Du har ingen samtaler. Når du starter en ny samtale vil den vises her.
                 </div>
             </div>
+            <div if:true={showInterpreterInterpreterThreads}>
+                <div class="record-details-container" if:false={noInterpreterInterpreterThreads}>
+                    <c-table
+                        records={interpreterInterpreterThreads}
+                        columns={columns}
+                        onrowclick={openThread}
+                        icon-by-value={iconByValue}
+                    ></c-table>
+                </div>
+                <div if:true={noInterpreterInterpreterThreads} style="text-align: center">
+                    <br />
+                    Du har ingen samtaler. Når du starter en ny samtale vil den vises her.
+                </div>
+            </div>
         </div>
     </main>
 </template>

--- a/force-app/main/dialogue/external-components/lwc/hot_threadList/hot_threadList.js
+++ b/force-app/main/dialogue/external-components/lwc/hot_threadList/hot_threadList.js
@@ -140,6 +140,7 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.showOrderthreads = false;
                     this.showWageClaimthreads = false;
                     this.showOrdererUserThreads = false;
+                    this.showInterpreterInterpreterThreads = false;
                 }
                 if (this.activeTab == 'interpreterthreads') {
                     this.showMythreads = false;
@@ -147,6 +148,7 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.showOrderthreads = false;
                     this.showWageClaimthreads = false;
                     this.showOrdererUserThreads = false;
+                    this.showInterpreterInterpreterThreads = false;
                 }
                 if (this.activeTab == 'orderThreads') {
                     this.showMythreads = false;
@@ -154,6 +156,7 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.showOrderthreads = true;
                     this.showWageClaimthreads = false;
                     this.showOrdererUserThreads = false;
+                    this.showInterpreterInterpreterThreads = false;
                 }
                 if (this.activeTab == 'wageClaimThreads') {
                     this.showMythreads = false;
@@ -161,6 +164,7 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.showOrderthreads = false;
                     this.showWageClaimthreads = true;
                     this.showOrdererUserThreads = false;
+                    this.showInterpreterInterpreterThreads = false;
                 }
                 if (this.activeTab == 'ordererUserThreads') {
                     this.showMythreads = false;
@@ -168,6 +172,15 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.showOrderthreads = false;
                     this.showWageClaimthreads = false;
                     this.showOrdererUserThreads = true;
+                    this.showInterpreterInterpreterThreads = false;
+                }
+                if (this.activeTab == 'interpreterInterpreterThreads') {
+                    this.showMythreads = false;
+                    this.showInterpreterthreads = false;
+                    this.showOrderthreads = false;
+                    this.showWageClaimthreads = false;
+                    this.showOrdererUserThreads = false;
+                    this.showInterpreterInterpreterThreads = true;
                 }
             }
         }
@@ -189,28 +202,33 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
     @track orderThreads;
     @track wageClaimThreads;
     @track ordererUserThreads;
+    @track interpreterInterpreterThreads;
 
     @track unmappedThreads;
     @track unmappedInterpreterThreads;
     @track unmapperOrderThreads;
     @track unmappedWageClaimThreads;
     @track unmappedOrdererUserTreads;
+    @track unmappedInterpreterInterpreterThreads;
 
     showMythreads = true;
     showInterpreterthreads = false;
     showOrderthreads = false;
     showWageClaimthreads = false;
     showOrdererUserThreads = false;
+    showInterpreterInterpreterThreads = false;
 
     noThreads = false;
     noInterpreterThreads = false;
     noOrderThreads = false;
     noWageClaimThreads = false;
     noOrdererUserThreads = false;
+    noInterpreterInterpreterThreads = false;
 
     ordererThreadsExisting = 0;
     wageClaimThreadsExisting = 0;
     ordererUserThreadsExisting = 0;
+    interpreterInterpreterThreadsExisting = 0;
 
     wiredThreadsResult;
     @wire(getMyThreads)
@@ -226,6 +244,7 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     this.unmapperOrderThreads = [];
                     this.unmappedWageClaimThreads = [];
                     this.unmappedOrdererUserTreads = [];
+                    this.unmappedInterpreterInterpreterThreads = [];
 
                     result.data.forEach((element) => {
                         if (element.CRM_Type__c == 'HOT_BRUKER-TOLK') {
@@ -249,7 +268,23 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                             this.unmappedOrdererUserTreads.push(element);
                             this.ordererUserThreadsExisting++;
                         }
+                        if (element.CRM_Type__c == 'HOT_TOLK-TOLK') {
+                            this.unmappedInterpreterInterpreterThreads.push(element);
+                            this.interpreterInterpreterThreadsExisting++;
+                            console.log('yesssss');
+                        }
                     });
+                    if (this.interpreterInterpreterThreadsExisting > 0) {
+                        if (this.tabs.some((tab) => tab.name === 'interpreterInterpreterThreads')) {
+                        } else {
+                            this.tabs.push({
+                                name: 'interpreterInterpreterThreads',
+                                label: 'Tolk-Tolk',
+                                selected: false,
+                                hasUnread: false
+                            });
+                        }
+                    }
                     if (this.ordererUserThreadsExisting > 0) {
                         if (this.tabs.some((tab) => tab.name === 'ordererUserThreads')) {
                         } else {
@@ -308,12 +343,18 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                         read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
                         LastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c)
                     }));
+                    this.interpreterInterpreterThreads = this.unmappedInterpreterInterpreterThreads.map((x) => ({
+                        ...x,
+                        read: !String(x.HOT_Thread_read_by__c).includes(contactId) ? false : true,
+                        LastMessage: this.formatDateTime(x.CRM_Latest_Message_Datetime__c)
+                    }));
 
                     this.noThreads = this.threads.length === 0;
                     this.noInterpreterThreads = this.interpreterThreads.length === 0;
                     this.noOrderThreads = this.orderThreads.length === 0;
                     this.noWageClaimThreads = this.wageClaimThreads.length === 0;
                     this.noOrdererUserThreads = this.ordererUserThreads.length === 0;
+                    this.noInterpreterInterpreterThreads = this.interpreterInterpreterThreads.length === 0;
 
                     //sorting, unread first
                     this.threads.sort((a, b) => {
@@ -353,6 +394,15 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                         return 1;
                     });
                     this.ordererUserThreads.sort((a, b) => {
+                        if (a.read === b.read) {
+                            return 0;
+                        }
+                        if (a.read === false) {
+                            return -1;
+                        }
+                        return 1;
+                    });
+                    this.interpreterInterpreterThreads.sort((a, b) => {
                         if (a.read === b.read) {
                             return 0;
                         }
@@ -485,6 +535,32 @@ export default class Hot_threadList extends NavigationMixin(LightningElement) {
                     } else {
                         this.tabs = this.tabs.map((tab) => {
                             if (tab.name === 'ordererUserThreads') {
+                                return { ...tab, hasUnread: false };
+                            }
+                            return tab;
+                        });
+                    }
+                    //List 6 unread messages
+
+                    let foundUnreadInterpreterInterpreterThreads = false;
+
+                    for (let i = 0; i < this.interpreterInterpreterThreads.length; i++) {
+                        const thread6 = this.interpreterInterpreterThreads[i];
+                        if (thread6.read == false) {
+                            foundUnreadInterpreterInterpreterThreads = true;
+                            break;
+                        }
+                    }
+                    if (foundUnreadInterpreterInterpreterThreads) {
+                        this.tabs = this.tabs.map((tab) => {
+                            if (tab.name === 'interpreterInterpreterThreads') {
+                                return { ...tab, hasUnread: true };
+                            }
+                            return tab;
+                        });
+                    } else {
+                        this.tabs = this.tabs.map((tab) => {
+                            if (tab.name === 'interpreterInterpreterThreads') {
                                 return { ...tab, hasUnread: false };
                             }
                             return tab;

--- a/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
+++ b/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
@@ -75,6 +75,25 @@
                         onclick={goToThreadTypeUserOrderer}
                     ></lightning-button>
                 </template>
+                <!--  -->
+                <template if:true={showUserInterpreterThreadbutton}>
+                    <lightning-button
+                        label="Samtale mellom bruker og tolk"
+                        variant="border-filled"
+                        slot="actions"
+                        onclick={goToThreadTypeUserInterpreter}
+                    ></lightning-button>
+                </template>
+                <template if:true={showInterpreterInterpreterThreadbutton}>
+                    <lightning-button
+                        label="Samtale mellom medtolker"
+                        variant="border-filled"
+                        slot="actions"
+                        onclick={goToThreadTypeInterpreterInterpreter}
+                    ></lightning-button>
+                </template>
+
+                <!--  -->
                 <template lwc:if={ThreadInfo}>
                     <span class="slds-badge slds-theme_success">{ThreadInfo}</span>
                 </template>

--- a/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.js
+++ b/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.js
@@ -5,6 +5,7 @@ import markAsReadByNav from '@salesforce/apex/HOT_MessageHelper.markAsReadByNav'
 import getAccountOnThread from '@salesforce/apex/HOT_MessageHelper.getAccountOnThread';
 import getAccountOnRequest from '@salesforce/apex/HOT_MessageHelper.getAccountOnRequest';
 import getRequestInformation from '@salesforce/apex/HOT_MessageHelper.getRequestInformation';
+import getWorkOrderInformation from '@salesforce/apex/HOT_MessageHelper.getWorkOrderInformation';
 import getAccountOnWorkOrder from '@salesforce/apex/HOT_MessageHelper.getAccountOnWorkOrder';
 import { refreshApex } from '@salesforce/apex';
 
@@ -17,6 +18,8 @@ export default class CrmMessagingMessageComponent extends LightningElement {
     showUserThreadbutton = false;
     showOrderThreadbutton = false;
     showUserOrdererThreadbutton = false;
+    showUserInterpreterThreadbutton = false;
+    showInterpreterInterpreterThreadbutton = false;
     activeSectionMessage = '';
     threads;
     setCardTitle;
@@ -63,12 +66,9 @@ export default class CrmMessagingMessageComponent extends LightningElement {
                     getAccountOnThread({ recordId: this.threads[0].Id })
                         .then((result) => {
                             this.accountName = result;
-                            console.log(this.accountName);
                             this.showAccountName = true;
                         })
-                        .catch((error) => {
-                            console.log('feil');
-                        });
+                        .catch((error) => {});
                 }
             }
         }
@@ -121,6 +121,57 @@ export default class CrmMessagingMessageComponent extends LightningElement {
 
     get shownewbutton() {
         return this.threads.length == 0;
+    }
+    goToThreadTypeInterpreterInterpreter() {
+        this.noThreadExist = false;
+        this.ThreadInfo = 'Du er i samtale med mellom medtolker';
+        refreshApex(this._threadsforRefresh);
+        for (let thread in this.threads) {
+            if (this.threads[thread].CRM_Type__c == 'HOT_TOLK-TOLK') {
+                this.messageType = 'HOT_TOLK-TOLK';
+                this.singleThread = true;
+                refreshApex(this._threadsforRefresh);
+                this.showThreads = true;
+                this.showAccountName = true;
+                event.preventDefault(); // prevent the default scroll behavior
+                event.stopPropagation();
+                break;
+            } else {
+                this.messageType = 'HOT_TOLK-TOLK';
+                this.buttonMessage = 'Klikk for å starte samtale med medtolker';
+            }
+        }
+        if (this.threads.length == 0) {
+            this.shownewbutton = true;
+            this.messageType = 'HOT_TOLK-TOLK';
+            this.buttonMessage = 'Klikk for å starte samtale med medtolker';
+        }
+    }
+
+    goToThreadTypeUserInterpreter() {
+        this.noThreadExist = false;
+        this.ThreadInfo = 'Du er i samtale med mellom bruker og tolker';
+        refreshApex(this._threadsforRefresh);
+        for (let thread in this.threads) {
+            if (this.threads[thread].CRM_Type__c == 'HOT_BRUKER-TOLK') {
+                this.messageType = 'HOT_BRUKER-TOLK';
+                this.singleThread = true;
+                refreshApex(this._threadsforRefresh);
+                this.showThreads = true;
+                this.showAccountName = true;
+                event.preventDefault(); // prevent the default scroll behavior
+                event.stopPropagation();
+                break;
+            } else {
+                this.messageType = 'HOT_BRUKER-TOLK';
+                this.buttonMessage = 'Klikk for å starte samtale med bruker og tolker';
+            }
+        }
+        if (this.threads.length == 0) {
+            this.shownewbutton = true;
+            this.messageType = 'HOT_BRUKER-TOLK';
+            this.buttonMessage = 'Klikk for å starte samtale med bruker og tolker';
+        }
     }
     goToThreadTypeOrderer() {
         this.noThreadExist = false;
@@ -233,10 +284,22 @@ export default class CrmMessagingMessageComponent extends LightningElement {
                 }
             })
             .catch((error) => {
-                this.isRequestMessages = false;
-                this.shownewbutton = true;
-                this.showThreads = true;
-                this.buttonMessage = 'Klikk for å starte samtale';
+                getWorkOrderInformation({ recordId: this.recordId })
+                    .then((result) => {
+                        if (result[0].HOT_TotalNumberOfInterpreters__c > 1) {
+                            this.showInterpreterInterpreterThreadbutton = true;
+                            this.showUserInterpreterThreadbutton = true;
+                        } else {
+                            this.showInterpreterInterpreterThreadbutton = false;
+                            this.showUserInterpreterThreadbutton = true;
+                        }
+                    })
+                    .catch((error) => {
+                        this.isRequestMessages = false;
+                        this.shownewbutton = true;
+                        this.showThreads = true;
+                        this.buttonMessage = 'Klikk for å starte samtale';
+                    });
             });
     }
 }

--- a/force-app/main/freelanceCommunity/classes/HOT_MyServiceAppointmentListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_MyServiceAppointmentListController.cls
@@ -100,6 +100,7 @@ public without sharing class HOT_MyServiceAppointmentListController {
                 HOT_ServiceTerritoryDeveloperName__c,
                 HOT_DegreeOfHearingAndVisualImpairment__c,
                 HOT_HapticCommunication__c,
+                HOT_TotalNumberOfInterpreters__c,
                 HOT_Escort__c,
                 HOT_AssignmentType__c,
                 HOT_FreelanceSubject__c,
@@ -128,7 +129,7 @@ public without sharing class HOT_MyServiceAppointmentListController {
         ServiceAppointment serviceAppointment=[SELECT HOT_WorkOrderLineItem__r.WorkOrderId FROM ServiceAppointment WHERE Id=:serviceAppointmentId];
         try{
 
-            Thread__c thread = [SELECT Id FROM Thread__c WHERE CRM_Related_Object__c=:serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId LIMIT 1];
+            Thread__c thread = [SELECT Id FROM Thread__c WHERE CRM_Related_Object__c=:serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId AND CRM_Thread_Type__c='HOT_BRUKER-TOLK' LIMIT 1];
              if (thread.Id != null) {
                Id=thread.Id;
                return Id;
@@ -165,5 +166,23 @@ public without sharing class HOT_MyServiceAppointmentListController {
             phonenumber=sa.HOT_Request__r.Orderer__r.CRM_Person__r.INT_KrrMobilePhone__c;
         }
         return phoneNumber;
+    }
+     @AuraEnabled
+    public static String getThreadInterpretersId(String serviceAppointmentId) {
+         String Id='';
+        ServiceAppointment serviceAppointment=[SELECT HOT_WorkOrderLineItem__r.WorkOrderId FROM ServiceAppointment WHERE Id=:serviceAppointmentId];
+        try{
+
+            Thread__c thread = [SELECT Id FROM Thread__c WHERE CRM_Related_Object__c=:serviceAppointment.HOT_WorkOrderLineItem__r.WorkOrderId AND CRM_Thread_Type__c='HOT_TOLK-TOLK' LIMIT 1];
+             if (thread.Id != null) {
+               Id=thread.Id;
+               return Id;
+             }
+             
+            return Id;
+        }catch(Exception E){
+
+        }
+        return Id;
     }
 }

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.html
@@ -91,6 +91,16 @@
                             >
                             </c-button>
                         </div>
+                        <div style="display: inline-block; padding-right: 1vw; padding-bottom: 1vw; padding-top: 1vw">
+                            <c-button
+                                button-styling="Primary"
+                                type="Submit"
+                                onbuttonclick={goToThreadInterpreters}
+                                disabled={isGoToThreadInterpretersButtonDisabled}
+                                button-label="Samtale med medtolker"
+                            >
+                            </c-button>
+                        </div>
                         <div style="display: inline-block; padding-right: 1vw">
                             <c-button
                                 button-styling="Primary"

--- a/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_myServiceAppointments/hot_myServiceAppointments.js
@@ -5,8 +5,10 @@ import getOrdererInformation from '@salesforce/apex/HOT_MyServiceAppointmentList
 import getServiceResource from '@salesforce/apex/HOT_Utility.getServiceResource';
 import getThreadFreelanceId from '@salesforce/apex/HOT_MyServiceAppointmentListController.getThreadFreelanceId';
 import getThreadServiceAppointmentId from '@salesforce/apex/HOT_MyServiceAppointmentListController.getThreadServiceAppointmentId';
+import getThreadInterpretersId from '@salesforce/apex/HOT_MyServiceAppointmentListController.getThreadInterpretersId';
 import createThread from '@salesforce/apex/HOT_MessageHelper.createThread';
 import createThreadInterpreter from '@salesforce/apex/HOT_MessageHelper.createThreadInterpreter';
+import createThreadInterpreters from '@salesforce/apex/HOT_MessageHelper.createThreadInterpreters';
 import { NavigationMixin } from 'lightning/navigation';
 import { columns, mobileColumns } from './columns';
 import { defaultFilters, compare } from './filters';
@@ -21,6 +23,7 @@ export default class Hot_myServiceAppointments extends NavigationMixin(Lightning
     freelanceThreadId;
     isGoToThreadButtonDisabled = false;
     isGoToThreadServiceAppointmentButtonDisabled = false;
+    isGoToThreadInterpretersButtonDisabled = false;
     setColumns() {
         if (window.screen.width > 576) {
             this.columns = columns;
@@ -182,6 +185,9 @@ export default class Hot_myServiceAppointments extends NavigationMixin(Lightning
                 if (this.serviceAppointment.Status == 'Completed') {
                     this.isEditButtonDisabled = true;
                 }
+                if (this.serviceAppointment.HOT_TotalNumberOfInterpreters__c <= 1) {
+                    this.isGoToThreadInterpretersButtonDisabled = true;
+                }
             }
         }
         this.updateURL();
@@ -303,6 +309,29 @@ export default class Hot_myServiceAppointments extends NavigationMixin(Lightning
                     .then((result) => {
                         this.navigateToThread(result.Id);
                         this.saThreadId = result;
+                    })
+                    .catch((error) => {
+                        this.modalHeader = 'Noe gikk galt';
+                        this.modalContent = 'Kunne ikke åpne samtale. Feilmelding: ' + error;
+                        this.noCancelButton = true;
+                        this.showModal();
+                    });
+            }
+        });
+    }
+    goToThreadInterpreters() {
+        this.isGoToThreadInterpretersButtonDisabled = true;
+        getThreadInterpretersId({ serviceAppointmentId: this.serviceAppointment.Id }).then((result) => {
+            if (result != '') {
+                this.freelanceThreadId = result;
+                this.navigateToThread(this.freelanceThreadId);
+                console.log('finnes');
+            } else {
+                console.log('finnes ingen');
+                createThreadInterpreters({ recordId: this.serviceAppointment.Id })
+                    .then((result) => {
+                        this.navigateToThread(result.Id);
+                        this.freelanceThreadId = result;
                     })
                     .catch((error) => {
                         this.modalHeader = 'Noe gikk galt';


### PR DESCRIPTION
### Ny dialogtype SAMTALE TOLK-TOLK.

Når tolk er tildelt oppdraget vil oppdraget ligge på "mine oppdrag" listen. Her kan frilanstolk nå velge mellom snakke med tolk og bruker, eller bare medtolker. Samme med formidler.

**KUN 1 TOLK:**
Sjekk at frilanstolk bare kan starte samtale med medtolk om det finnes flere enn 1 tolk på oppdraget. Ellers vil knappen være disablet. Samme med formidler; Skal ikke kunne trykke samtale med medtolk med mindre det er mer enn 1 tolk.

**FLERE TOLKER PÅ OPPDRAGET:**
Som formidler: på wo trykk samtale med tolk og bruker, og lag en ny samtale med medtolk. **Husk å skriv meldinger.**
Logg inn i community og sjekk at samtalen du skrev mellom tolk-bruker dukker opp hos både tolk og bruker. Og samtalen du startet mellom medtolk kun dukket opp mellom medtolk.

Slett trådene.

Som frilanstolk: mine oppdrag listen. trykk  samtale med tolk og bruker, og lag en ny samtale med medtolk. **Husk å skriv meldinger.** 
Logg inn i community og sa og sjekk at samtalen du skrev mellom tolk-bruker dukker på WO og hos bruker. Og samtalen du startet mellom medtolk kun dukket opp mellom medtolk.
 
Slett trådene.

Som bruker: gå inn på oppdraget, og lag en ny samtale med tolk. **Husk å skriv meldinger.**
Logg inn i community og Saleforce og sjekk at samtalen du skrev mellom tolk-bruker dukker opp på WO "samtale med tolk bruker" og bruker community.

Sjekk at samtalen forsvinner når tolk tas av oppdraget.

