### PR TITLE
Merke at et oppdrag haster.

### DIFF
--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/columns.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/columns.js
@@ -18,14 +18,13 @@ export let columns = [
         label: 'Tema',
         name: 'HOT_FreelanceSubject__c',
         type: 'String'
+    },
+    {
+        label: '',
+        name: 'isUrgent',
+        type: 'boolean',
+        svg: true
     }
-    //,
-    // {
-    //     label: '',
-    //     name: 'isUrgent',
-    //     type: 'boolean',
-    //     svg: true
-    // }
 ];
 export let inDetailsColumns = [
     {
@@ -60,12 +59,11 @@ export let mobileColumns = [
         label: 'Tema',
         name: 'HOT_FreelanceSubject__c',
         type: 'String'
+    },
+    {
+        label: '',
+        name: 'isUrgent',
+        type: 'boolean',
+        svg: true
     }
-    // ,
-    // {
-    //     label: '',
-    //     name: 'isUrgent',
-    //     type: 'boolean',
-    //     svg: true
-    // }
 ];

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.html
@@ -25,17 +25,8 @@
                 checkbox="true"
                 checked-rows={checkedServiceAppointments}
                 oncheckedrows={handleRowChecked}
-            ></c-table>
-            <!-- <c-table
-                if:false={noServiceAppointments}
-                records={records}
-                columns={columns}
-                onrowclick={goToRecordDetails}
-                checkbox="true"
-                checked-rows={checkedServiceAppointments}
-                oncheckedrows={handleRowChecked}
                 icon-by-value={iconByValue}
-            ></c-table> -->
+            ></c-table>
         </div>
         <div if:true={noServiceAppointments} style="text-align: center">
             <br />

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -149,8 +149,8 @@ export default class Hot_openServiceAppointments extends LightningElement {
             this.error = undefined;
             this.allServiceAppointmentsWired = result.data.map((x) => ({
                 ...x,
-                weekday: this.getDayOfWeek(x.EarliestStartTime)
-                //,isUrgent: x.HOT_IsUrgent__c
+                weekday: this.getDayOfWeek(x.EarliestStartTime),
+                isUrgent: x.HOT_IsUrgent__c
             }));
             this.noServiceAppointments = this.allServiceAppointmentsWired.length === 0;
             let tempRecords = [];

--- a/force-app/main/triggers/classes/HOT_ServiceAppointmentHandler.cls
+++ b/force-app/main/triggers/classes/HOT_ServiceAppointmentHandler.cls
@@ -869,14 +869,6 @@ public without sharing class HOT_ServiceAppointmentHandler extends MyTriggers {
             if (serviceAppointment.HOT_DeadlineDate__c == null) {
                 serviceAppointment.HOT_DeadlineDate__c = serviceAppointment.EarliestStartTime.date();
             }
-            Date today = Date.today();
-            Date tomorrow = today.addDays(1);
-            for(ServiceAppointment sa: serviceAppointments){
-                Date saDate = sa.SchedStartTime.date();
-                if(saDate==today || saDate==tomorrow ){
-                    // sa.HOT_IsUrgent__c=true;
-                }
-            }
             serviceAppointment.HOT_IsEmployedInterpreter__c = false;
             serviceAppointment.HOT_IsReleasedToFreelance__c = true;
             serviceAppointment.HOT_ReleaseDate__c = Date.today();


### PR DESCRIPTION
ST snakket med dem og de ønsker ikke automatikk. Dermed må de manuelt merke om et oppdrag haster eller ikke.

Sjekk at det ikke finnes noe automatikk på feltet. Lag et oppdrag og på SA kan du merke et oppdrag som "urgent". Frigjør til frilans og på frilans ledige oppdrag skal det være et ikon om det er merket som haster. 


**OPPRINNELIG:**

https://github.com/navikt/crm-hot/pull/1557/files#diff-f0cfa4c6bd92609745948efef5843e4880cf70fa48dac8960d484fd778eb0480

**KOMMENTERT UT FOR Å FJERNE AUTOMATIKK:**
https://github.com/navikt/crm-hot/pull/1568/files
<img width="1409" alt="Skjermbilde 2023-05-10 kl  12 22 55" src="https://github.com/navikt/crm-hot/assets/111959793/e7d54956-11ee-4e78-9bcd-8b7ae815e4d6">


