### PR TITLE
Endret tekst på høyt prioriterte oppdrag

### DIFF
--- a/force-app/main/default/objectTranslations/ServiceAppointment-no/HOT_IsUrgent__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceAppointment-no/HOT_IsUrgent__c.fieldTranslation-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
-    <label>Haster oppdraget?</label>
+    <label>Høyt prioritert oppdrag?</label>
     <name>HOT_IsUrgent__c</name>
 </CustomFieldTranslation>

--- a/force-app/main/default/objects/ServiceAppointment/fields/HOT_IsUrgent__c.field-meta.xml
+++ b/force-app/main/default/objects/ServiceAppointment/fields/HOT_IsUrgent__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>HOT_IsUrgent__c</fullName>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
-    <label>Is urgent?</label>
+    <label>High priority?</label>
     <trackHistory>false</trackHistory>
     <type>Checkbox</type>
 </CustomField>

--- a/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
+++ b/force-app/main/freelanceCommunity/lwc/hot_openServiceAppointments/hot_openServiceAppointments.js
@@ -28,7 +28,7 @@ export default class Hot_openServiceAppointments extends LightningElement {
         true: {
             icon: 'WarningFilled',
             fill: 'Red',
-            ariaLabel: 'Dette oppdraget haster'
+            ariaLabel: 'Høyt prioritert'
         }
     };
 


### PR DESCRIPTION
Sjekk at det står 

"Høyt prioritert oppdrag?" på feltet på SA på formidler på norsk.

"Høyt prioritert" på oppdrag som er merket for frilanstolker.