### PR TITLE
Ingen samtale mellom bruker og bestiller

### DIFF
--- a/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
+++ b/force-app/main/dialogue/internal-components/lwc/hot_messagingMessageComponent/hot_messagingMessageComponent.html
@@ -67,14 +67,14 @@
                         onclick={goToThreadTypeUser}
                     ></lightning-button>
                 </template>
-                <template if:true={showUserOrdererThreadbutton}>
+                <!-- <template if:true={showUserOrdererThreadbutton}>
                     <lightning-button
                         label="Samtale mellom bruker og bestiller"
                         variant="border-filled"
                         slot="actions"
                         onclick={goToThreadTypeUserOrderer}
                     ></lightning-button>
-                </template>
+                </template> -->
                 <!--  -->
                 <template if:true={showUserInterpreterThreadbutton}>
                     <lightning-button

--- a/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.html
+++ b/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.html
@@ -190,7 +190,7 @@
                     mobile-style="justify-content: center"
                     onbuttonclick={goToThreadInterpreter}
                 ></c-button>
-                <c-button
+                <!-- <c-button
                     if:false={isAccountEqualOrderer}
                     button-label={threadOrdererUserButtonLabel}
                     button-styling="primary"
@@ -198,7 +198,7 @@
                     desktop-style="justify-content: center"
                     mobile-style="justify-content: center"
                     onbuttonclick={goToThreadOrdererUser}
-                ></c-button>
+                ></c-button> -->
             </div>
             <div class="record-details-container" if:false={noWorkOrders}>
                 <c-table


### PR DESCRIPTION
Det er ikke lenger ønskelig med samtale bruker og bestiller da det kunne føre til at meldinger som ikke var ment til å gå gjennom NAV kunne bli sendt her. Eks: meldinger mellom tolkebruker - lege/sykehus osv. 
ST var enig om å bare skjule knappene i tilfelle det skulle være ønskelig senere.