### PR TITLE
TOLK 1645 - statusflyt interessert ressurs ved påmelding samtidig som tildeling av annen ressurs

### DIFF
--- a/force-app/main/triggers/classes/HOT_InterestedResourceHandler.cls
+++ b/force-app/main/triggers/classes/HOT_InterestedResourceHandler.cls
@@ -72,10 +72,9 @@ public without sharing class HOT_InterestedResourceHandler extends MyTriggers {
     }
           public void updateInterestedResourceStatus(List<SObject> records) {
     Set<Id> serviceAppointmentIds = new Set<Id>();
-     List<HOT_InterestedResource__c> newIrList=[SELECT Id, ServiceAppointment__c
-        FROM HOT_InterestedResource__c WHERE Id IN: records];
-for (HOT_InterestedResource__c interestedResource : newIrList) {
-         serviceAppointmentIds.add(interestedResource.ServiceAppointment__c);
+
+     for (HOT_InterestedResource__c interestedResource : (List<HOT_InterestedResource__c>) records) {
+        serviceAppointmentIds.add(interestedResource.ServiceAppointment__c);
      }
         List<HOT_InterestedResource__c> existingInterestedResources = [
         SELECT Id, ServiceAppointment__c
@@ -88,10 +87,11 @@ for (HOT_InterestedResource__c interestedResource : newIrList) {
         irMap.put(existingInterestedResource.ServiceAppointment__c,existingInterestedResource.Id);
     }
     List<HOT_InterestedResource__c> recordsToUpdate = new List<HOT_InterestedResource__c>();
-    for (HOT_InterestedResource__c interestedResource : newIrList) {
+    for (HOT_InterestedResource__c interestedResource : (List<HOT_InterestedResource__c>) records) {
         if (irMap.containsKey(interestedResource.ServiceAppointment__c)) {
-                interestedResource.Status__c='Not Assigned';
-                recordsToUpdate.add(interestedResource);
+            HOT_InterestedResource__c irToUpdate=new HOT_InterestedResource__c(Id=interestedResource.Id, Status__c='Not Assigned');
+                recordsToUpdate.add(irToUpdate);
+
         } 
     }
     if (recordsToUpdate.size() > 0) {

--- a/force-app/main/triggers/classes/HOT_InterestedResourceHandler.cls
+++ b/force-app/main/triggers/classes/HOT_InterestedResourceHandler.cls
@@ -1,6 +1,7 @@
 public without sharing class HOT_InterestedResourceHandler extends MyTriggers {
     public override void onAfterInsert() {
         updateInterestedResourceNamesOnServiceAppointments(records, null, false);
+        updateInterestedResourceStatus(records);
     }
 
     public override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
@@ -68,5 +69,33 @@ public without sharing class HOT_InterestedResourceHandler extends MyTriggers {
             serviceAppointmentsToUpdate.add(serviceAppointment);
         }
         update serviceAppointmentsToUpdate;
+    }
+          public void updateInterestedResourceStatus(List<SObject> records) {
+    Set<Id> serviceAppointmentIds = new Set<Id>();
+     List<HOT_InterestedResource__c> newIrList=[SELECT Id, ServiceAppointment__c
+        FROM HOT_InterestedResource__c WHERE Id IN: records];
+for (HOT_InterestedResource__c interestedResource : newIrList) {
+         serviceAppointmentIds.add(interestedResource.ServiceAppointment__c);
+     }
+        List<HOT_InterestedResource__c> existingInterestedResources = [
+        SELECT Id, ServiceAppointment__c
+        FROM HOT_InterestedResource__c
+        WHERE ServiceAppointment__c IN :serviceAppointmentIds
+        AND Status__c = 'Assigned'
+    ];
+    Map<Id,Id> irMap = new Map<Id,Id>();
+    for (HOT_InterestedResource__c existingInterestedResource : existingInterestedResources) {
+        irMap.put(existingInterestedResource.ServiceAppointment__c,existingInterestedResource.Id);
+    }
+    List<HOT_InterestedResource__c> recordsToUpdate = new List<HOT_InterestedResource__c>();
+    for (HOT_InterestedResource__c interestedResource : newIrList) {
+        if (irMap.containsKey(interestedResource.ServiceAppointment__c)) {
+                interestedResource.Status__c='Not Assigned';
+                recordsToUpdate.add(interestedResource);
+        } 
+    }
+    if (recordsToUpdate.size() > 0) {
+        update recordsToUpdate;
+    }
     }
 }

--- a/force-app/main/triggers/classes/HOT_InterestedResourceHandlerTest.cls
+++ b/force-app/main/triggers/classes/HOT_InterestedResourceHandlerTest.cls
@@ -139,4 +139,33 @@ private class HOT_InterestedResourceHandlerTest {
         String names = serviceAppointment.HOT_InterestedResourceNames__c;
         System.assertEquals(names.substring(names.length() - 3, names.length()), '...');
     }
+             @isTest
+    static void changeStatusOfInterestedResourceWhenAnIrIsAlreadyAssigned() {
+        ServiceAppointment serviceAppointment = [SELECT Id FROM ServiceAppointment LIMIT 1];
+
+        HOT_InterestedResource__c interestedResource = [
+            SELECT Status__c
+            FROM HOT_InterestedResource__c
+            WHERE ServiceAppointment__c = :serviceAppointment.Id
+            LIMIT 1
+        ];
+
+        interestedResource.Status__c = 'Assigned';
+        Test.startTest();
+        update interestedResource;
+        
+         User admin = [SELECT Id, UserRoleId FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1];
+
+        ServiceResource serviceResource = HOT_TestDataFactory.createServiceResource(admin.Id);
+        insert serviceResource;
+
+        HOT_InterestedResource__c interestedResource2=HOT_TestDataFactory.createInterestedResource(ServiceAppointment.Id, serviceResource.Id);
+        insert interestedResource2;
+        Test.stopTest();
+
+        HOT_InterestedResource__c irToCheck = [SELECT Status__c, ServiceResource__c FROM HOT_InterestedResource__c WHERE Id=:interestedResource2.Id];
+
+
+        System.assertEquals('Not Assigned', irToCheck.Status__c);
+    }
 }

--- a/force-app/main/wageClaim/classes/HOT_WageClaimServiceTest.cls
+++ b/force-app/main/wageClaim/classes/HOT_WageClaimServiceTest.cls
@@ -65,9 +65,9 @@ private class HOT_WageClaimServiceTest {
 
     @isTest
     static void getServiceAppointmentsTest() {
+        Test.startTest();
         AssignedResource assignedResource = [SELECT Id, ServiceAppointmentId FROM AssignedResource];
         update new ServiceAppointment(Id = assignedResource.ServiceAppointmentId, Status = 'None');
-        Test.startTest();
         HOT_WageClaim__c wageClaim = [SELECT Id, ServiceResource__c FROM HOT_WageClaim__c LIMIT 1];
         List<ServiceAppointment> serviceAppointments = HOT_WageClaimService.getServiceAppointments(wageClaim.Id);
         Test.stopTest();


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-1645

Når frilanstolk melder interesse til et oppdrag samtidig som formidler tildeler en annen tolk oppdraget, vil IR nå få automatisk status 'Ikke tildelt deg'

TEST:
Lag et oppdrag og frigi til frilans.
Logg inn i community og gå til ledige oppdrag liste.
Imens gå som formidler i salesforce og tildel oppdraget til en anne tolk.
I community så trykk meld interesse på det samme oppdraget
Sjekk nå at status på denne nye interesserte ressursen fikk status Ikke tildelt deg