### PR TITLE
TOLK-2303 : Fikser et kommende problem angående formidlers bruk av ønsket oppdrag og endrer gammel tekst

### DIFF
--- a/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
+++ b/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
@@ -297,8 +297,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>existingText</name>
-            <fieldText>&lt;p&gt;Tolken har allerede en interessert ressurs på oppdrag som tilhører
-                samme arbeidsordre.&lt;/p&gt;</fieldText>
+            <fieldText
+            >&lt;p&gt;Tolken har allerede en interessert ressurs på oppdrag som tilhører samme arbeidsordre.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -314,8 +314,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>NoFreelanceMessage</name>
-            <fieldText>&lt;p&gt;Ønsket tolk &lt;strong&gt;må&lt;/strong&gt; være en frilanstolk.
-                Trykk på tilbake og velg en annen&lt;/p&gt;</fieldText>
+            <fieldText
+            >&lt;p&gt;Ønsket tolk &lt;strong&gt;må&lt;/strong&gt; være en frilanstolk. Trykk på tilbake og velg en annen&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -331,8 +331,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>notReleasedText</name>
-            <fieldText>&lt;p&gt;Oppdraget må være frigitt til frilans før du kan registrere ønsket
-                frilanstolk.&lt;/p&gt;</fieldText>
+            <fieldText
+            >&lt;p&gt;Oppdraget må være frigitt til frilans før du kan registrere ønsket frilanstolk.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -348,8 +348,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>textoverlap</name>
-            <fieldText>&lt;p&gt;Tolken har overlappende oppdrag og kan derfor ikke registreres som
-                ønsket på dette oppdraget.&lt;/p&gt;</fieldText>
+            <fieldText
+            >&lt;p&gt;Tolken har overlappende oppdrag og kan derfor ikke registreres som ønsket på dette oppdraget.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -368,8 +368,8 @@
         </connector>
         <fields>
             <name>infotext</name>
-            <fieldText>&lt;p&gt;Når en ønsket tolk er registrert vil tolken få mulighet til å avslå
-                eller automatisk tildele seg selv oppdraget.&lt;/p&gt;</fieldText>
+            <fieldText
+            >&lt;p&gt;Når en ønsket tolk er registrert vil tolken få mulighet til å avslå eller melde interesse for oppdraget.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>

--- a/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
+++ b/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
-        <name>checkForOverlapSA</name>
-        <label>checkForOverlapSA</label>
-        <locationX>248</locationX>
+        <name>check_for_overlap_and_interested_ir</name>
+        <label>check for overlap and interested ir</label>
+        <locationX>380</locationX>
         <locationY>674</locationY>
         <actionName>HOT_wantedSRListController</actionName>
         <actionType>apex</actionType>
@@ -34,7 +34,7 @@
     <assignments>
         <name>change_status</name>
         <label>change status</label>
-        <locationX>314</locationX>
+        <locationX>578</locationX>
         <locationY>1106</locationY>
         <assignmentItems>
             <assignToReference>get_IR.Status__c</assignToReference>
@@ -50,7 +50,7 @@
     <decisions>
         <name>check_if_sr_is_freelance</name>
         <label>check if sr is freelance</label>
-        <locationX>545</locationX>
+        <locationX>743</locationX>
         <locationY>566</locationY>
         <defaultConnector>
             <targetReference>Is_not_freelance_message</targetReference>
@@ -67,7 +67,7 @@
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>checkForOverlapSA</targetReference>
+                <targetReference>check_for_overlap_and_interested_ir</targetReference>
             </connector>
             <label>Is freelance</label>
         </rules>
@@ -75,7 +75,7 @@
     <decisions>
         <name>checkSAReleasedToFreelance</name>
         <label>checkSAReleasedToFreelance</label>
-        <locationX>825</locationX>
+        <locationX>1056</locationX>
         <locationY>242</locationY>
         <defaultConnector>
             <targetReference>notReleasedScreen</targetReference>
@@ -100,7 +100,7 @@
     <decisions>
         <name>if_IR_not_exist</name>
         <label>if IR not exist</label>
-        <locationX>446</locationX>
+        <locationX>710</locationX>
         <locationY>998</locationY>
         <defaultConnector>
             <targetReference>New_wanted_interested_resource</targetReference>
@@ -125,7 +125,7 @@
     <decisions>
         <name>overlapDecision</name>
         <label>overlapDecision</label>
-        <locationX>248</locationX>
+        <locationX>380</locationX>
         <locationY>782</locationY>
         <defaultConnector>
             <targetReference>get_IR</targetReference>
@@ -144,7 +144,22 @@
             <connector>
                 <targetReference>overlapScreen</targetReference>
             </connector>
-            <label>Overlap</label>
+            <label>Overlap or existing ir on WO</label>
+        </rules>
+        <rules>
+            <name>existing_IR</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>overlappingSA</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>existing</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>existing</targetReference>
+            </connector>
+            <label>existing IR</label>
         </rules>
     </decisions>
     <environments>Default</environments>
@@ -172,7 +187,7 @@
     <recordCreates>
         <name>New_wanted_interested_resource</name>
         <label>New wanted interested resource</label>
-        <locationX>578</locationX>
+        <locationX>842</locationX>
         <locationY>1106</locationY>
         <inputAssignments>
             <field>ServiceAppointment__c</field>
@@ -198,7 +213,7 @@
     <recordLookups>
         <name>check_if_freelance</name>
         <label>check if freelance</label>
-        <locationX>545</locationX>
+        <locationX>743</locationX>
         <locationY>458</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -219,7 +234,7 @@
     <recordLookups>
         <name>get_IR</name>
         <label>get IR</label>
-        <locationX>446</locationX>
+        <locationX>710</locationX>
         <locationY>890</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -247,7 +262,7 @@
     <recordLookups>
         <name>getSA</name>
         <label>getSA</label>
-        <locationX>825</locationX>
+        <locationX>1056</locationX>
         <locationY>134</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -268,14 +283,31 @@
     <recordUpdates>
         <name>update_IR</name>
         <label>update IR</label>
-        <locationX>314</locationX>
+        <locationX>578</locationX>
         <locationY>1214</locationY>
         <inputReference>get_IR</inputReference>
     </recordUpdates>
     <screens>
+        <name>existing</name>
+        <label>existing</label>
+        <locationX>314</locationX>
+        <locationY>890</locationY>
+        <allowBack>false</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>false</allowPause>
+        <fields>
+            <name>existingText</name>
+            <fieldText>&lt;p&gt;Tolken har allerede en interessert ressurs på oppdrag som tilhører
+                samme arbeidsordre.&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>false</showHeader>
+    </screens>
+    <screens>
         <name>Is_not_freelance_message</name>
         <label>Is not freelance message</label>
-        <locationX>842</locationX>
+        <locationX>1106</locationX>
         <locationY>674</locationY>
         <allowBack>true</allowBack>
         <allowFinish>false</allowFinish>
@@ -292,7 +324,7 @@
     <screens>
         <name>notReleasedScreen</name>
         <label>notReleasedScreen</label>
-        <locationX>1106</locationX>
+        <locationX>1370</locationX>
         <locationY>350</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
@@ -326,7 +358,7 @@
     <screens>
         <name>registerWanterSr</name>
         <label>Register Wanter ServiceResource</label>
-        <locationX>545</locationX>
+        <locationX>743</locationX>
         <locationY>350</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
@@ -376,7 +408,7 @@
         <showHeader>false</showHeader>
     </screens>
     <start>
-        <locationX>699</locationX>
+        <locationX>930</locationX>
         <locationY>0</locationY>
         <connector>
             <targetReference>getSA</targetReference>

--- a/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
+++ b/force-app/main/default/flows/HOT_RegisterWantedServiceResource.flow-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <name>checkForOverlapSA</name>
@@ -282,7 +282,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>NoFreelanceMessage</name>
-            <fieldText>&lt;p&gt;Ønsket tolk &lt;strong&gt;må&lt;/strong&gt; være en frilanstolk. Trykk på tilbake og velg en annen&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;Ønsket tolk &lt;strong&gt;må&lt;/strong&gt; være en frilanstolk.
+                Trykk på tilbake og velg en annen&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -298,7 +299,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>notReleasedText</name>
-            <fieldText>&lt;p&gt;Oppdraget må være frigitt til frilans før du kan registrere ønsket frilanstolk.&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;Oppdraget må være frigitt til frilans før du kan registrere ønsket
+                frilanstolk.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -314,7 +316,8 @@
         <allowPause>false</allowPause>
         <fields>
             <name>textoverlap</name>
-            <fieldText>&lt;p&gt;Tolken har overlappende oppdrag og kan derfor ikke registreres som ønsket på dette oppdraget.&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;Tolken har overlappende oppdrag og kan derfor ikke registreres som
+                ønsket på dette oppdraget.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
@@ -333,7 +336,8 @@
         </connector>
         <fields>
             <name>infotext</name>
-            <fieldText>&lt;p&gt;Når en ønsket tolk er registrert vil tolken få mulighet til å avslå eller automatisk tildele seg selv oppdraget.&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;Når en ønsket tolk er registrert vil tolken få mulighet til å avslå
+                eller automatisk tildele seg selv oppdraget.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>

--- a/force-app/main/freelanceCommunity/classes/HOT_OpenServiceAppointmentListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_OpenServiceAppointmentListController.cls
@@ -20,14 +20,16 @@ public without sharing class HOT_OpenServiceAppointmentListController {
 
         //Getting ServiceAppointments of interest
         List<HOT_InterestedResource__c> interestedResources = [
-            SELECT ServiceAppointment__c
+            SELECT ServiceAppointment__c, ServiceAppointment__r.HOT_WorkOrderLineItem__r.WorkOrder.Id
             FROM HOT_InterestedResource__c
-            WHERE ServiceResource__c IN :serviceResource
+            WHERE Status__c = 'Wanted' AND ServiceResource__c IN :serviceResource
         ];
-        
+
         List<Id> interestedServiceAppointmentIds = new List<Id>();
+        List<Id> interestedWOIds = new List<Id>();
         for (HOT_InterestedResource__c ir : interestedResources) {
             interestedServiceAppointmentIds.add(ir.ServiceAppointment__c);
+            interestedWOIds.add(ir.ServiceAppointment__r.HOT_WorkOrderLineItem__r.WorkOrder.Id);
         }
 
         //Getting ServiceAppointments, filtered by isRealeased, Status, DeadlineDate
@@ -36,6 +38,7 @@ public without sharing class HOT_OpenServiceAppointmentListController {
             SELECT
                 Id,
                 HOT_ServiceAppointmentNumber__c,
+                HOT_WorkOrderLineItem__r.WorkOrder.Id,
                 ServiceTerritoryId,
                 EarliestStartTime,
                 DueDate,
@@ -71,7 +74,8 @@ public without sharing class HOT_OpenServiceAppointmentListController {
                 HOT_IsReleasedToFreelance__c = TRUE
                 AND Status = 'Released To Freelance'
                 AND HOT_DeadlineDate__c >= :DATE.TODAY()
-                AND (Id NOT IN :interestedServiceAppointmentIds)
+                AND Id NOT IN :interestedServiceAppointmentIds
+                AND HOT_WorkOrderLineItem__r.WorkOrder.Id NOT IN :interestedWOIds
                 AND ServiceTerritoryId != NULL
             ORDER BY EarliestStartTime ASC
         ];
@@ -120,7 +124,7 @@ public without sharing class HOT_OpenServiceAppointmentListController {
         Id userId = UserInfo.getUserId();
 
         ServiceResource serviceResource = [SELECT Id FROM ServiceResource WHERE RelatedRecordId = :userId];
-        
+
         List<HOT_InterestedResource__c> interestedResources = new List<Hot_InterestedResource__c>();
         for (Integer i = 0; i < serviceAppointmentIds.size(); i++) {
             HOT_InterestedResource__c IR = new HOT_InterestedResource__c(
@@ -133,7 +137,7 @@ public without sharing class HOT_OpenServiceAppointmentListController {
         insert interestedResources;
 
         for (Integer i = 0; i < serviceAppointmentIds.size(); i++) {
-            if(!String.isEmpty(comments[i])) {
+            if (!String.isEmpty(comments[i])) {
                 HOT_InterestedResourcesListController.startAThreadAndAddComment(interestedResources[i].Id, comments[i]);
             }
         }

--- a/force-app/main/freelanceCommunity/classes/HOT_OpenServiceAppointmentListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_OpenServiceAppointmentListController.cls
@@ -22,7 +22,7 @@ public without sharing class HOT_OpenServiceAppointmentListController {
         List<HOT_InterestedResource__c> interestedResources = [
             SELECT ServiceAppointment__c, ServiceAppointment__r.HOT_WorkOrderLineItem__r.WorkOrder.Id
             FROM HOT_InterestedResource__c
-            WHERE Status__c = 'Wanted' AND ServiceResource__c IN :serviceResource
+            WHERE ServiceResource__c IN :serviceResource
         ];
 
         List<Id> interestedServiceAppointmentIds = new List<Id>();

--- a/force-app/main/freelanceCommunity/classes/HOT_wantedSRListController.cls
+++ b/force-app/main/freelanceCommunity/classes/HOT_wantedSRListController.cls
@@ -272,20 +272,29 @@ public without sharing class HOT_wantedSRListController {
         }
     }
     @InvocableMethod(
-        label='Check if wanted SR has overlapping SA'
+        label='Check if wanted SR has overlapping SA and interested IR'
         description='return based on result'
         category='check'
     )
-    public static List<String> checkForOverlap(List<Request> ids) {
-        List<String> overLaps = new List<String>();
+    public static List<String> checkForOverlapOrExisting(List<Request> ids) {
+        List<String> status = new List<String>();
 
         List<ServiceAppointment> sa = [
-            SELECT Id, EarliestStartTime, DueDate
+            SELECT Id, EarliestStartTime, DueDate, HOT_WorkOrderLineItem__r.WorkOrderId
             FROM ServiceAppointment
             WHERE Id = :ids[0].saId
         ];
 
         ServiceResource serviceResource = [SELECT Id, Name FROM ServiceResource WHERE Id = :ids[0].srId];
+
+        List<HOT_InterestedResource__c> existingInterestedIR = [
+            SELECT Id, ServiceResource__c, Status__c
+            FROM HOT_InterestedResource__c
+            WHERE
+                ServiceResource__c = :serviceResource.Id
+                AND ServiceAppointment__r.HOT_WorkOrderLineItem__r.WorkOrderId = :sa[0]
+                    .HOT_WorkOrderLineItem__r.WorkOrderId
+        ];
 
         List<HOT_InterestedResource__c> assignedInterestedResources = [
             SELECT
@@ -328,13 +337,17 @@ public without sharing class HOT_wantedSRListController {
                 } else {
                 }
             }
-            if (overlapCount > 0) {
-                overLaps.add('overlap');
+            if (existingInterestedIR.size() > 0) {
+                status.add('existing');
             } else {
-                overLaps.add('no overlap');
+                if (overlapCount > 0) {
+                    status.add('overlap');
+                } else {
+                    status.add('no overlap');
+                }
             }
         }
-        return overLaps;
+        return status;
     }
 
     public class Request {


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2303

Om formidlere registrerer ønsket ressurs på oppdrag som tilhører samme arbeidsorder (som er unødvendig), så blir det bare kaos når frilanstolken melder interesse. Blir duplikater og masse styr. Frilanstolk trenger uansett KUN å melde interesse for det ene oppdraget.
-------------------------------
Så når ønsket ressurs skal registrers nå vil formidler få beskjed at ikke den kan registreres fordi det finnes allerede en IR med den tolken på et oppdrag tilhørende samme arbeidsordre. 

I tillegg endret jeg teksten som stod gjennom flowen. Det ble ikke endret sist etter ønskene.