### PR TITLE
Knapp blir nå resatt når bruker går inn på annet oppdrag -- > Master

### DIFF
--- a/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
+++ b/force-app/main/userCommunity/lwc/mineBestillingerWrapper/mineBestillingerWrapper.js
@@ -229,6 +229,7 @@ export default class MineBestillingerWrapper extends NavigationMixin(LightningEl
     isTheOrderer = true;
 
     setButtonLabels() {
+        this.isTheOrderer = true;
         if (this.urlStateParameters.level === 'R') {
             this.editButtonLabel = 'Rediger serie';
             this.copyButtonLabel = 'Kopier serie';


### PR DESCRIPTION
"Fått melding fra Trøndelag nå på morgenen at bruker ikke har fått avlyst en bestilling via tolkebestillingsløsningen.  Ser at vi har feil i UATHOT at avlys/avlys serie-knappen er grået ut.  Både det i prod og i uat er bestilling for seg selv."