### PR TITLE
TOLK-2377- Frilanstolk får ikke SMS varsel ved ny melding

### DIFF
--- a/force-app/main/sms/classes/HOT_ReminderSMSService.cls
+++ b/force-app/main/sms/classes/HOT_ReminderSMSService.cls
@@ -284,7 +284,7 @@ public without sharing class HOT_ReminderSMSService {
             logger.publishSynch();
         }
     }
-    @Future
+
     public static void sendSMSOnNewMessageInterpreter(String userId, String threadId) {
         User user = [SELECT Id, AccountId FROM User WHERE Id = :userId];
         List<SMS__c> smsList = new List<SMS__c>();


### PR DESCRIPTION
https://jira.adeo.no/browse/TOLK-2377

Siden det ble lagt til @Future på metoden HOT_MessagesNotification.NotifyInterpreter()  (https://github.com/navikt/crm-hot/pull/1843) og det allerede var @Future på metoden HOT_ReminderSMSService.sendSMSOnNewMessageInterpreter() første dette til at man fikk en feilmelding. Kan ikke kalle en future-metode fra en annen future-metode. Løste dette ved å fjerne @Future fra den siste (siden den da allerede er i en future-metode).